### PR TITLE
Add custom tnt ticks

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/module/type/TntCountdown.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/type/TntCountdown.java
@@ -1,0 +1,45 @@
+package com.lunarclient.apollo.module.type;
+
+import com.lunarclient.apollo.module.ApolloModule;
+import com.lunarclient.apollo.option.NumberOption;
+import com.lunarclient.apollo.player.ApolloPlayer;
+import io.leangen.geantyref.TypeToken;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.NonExtendable
+public abstract class TntCountdown extends ApolloModule {
+
+    /**
+     * Set the amount of ticks before the TNT explodes.
+     *
+     * @since 1.0.0
+     */
+    public static final NumberOption<Integer> TNT_TICKS = NumberOption.<Integer>number()
+            .comment("Set the amount of ticks before the TNT explodes.")
+            .node("tnt-ticks").type(TypeToken.get(Integer.class))
+            .defaultValue(80).min(1).max(Integer.MAX_VALUE).build();
+
+    TntCountdown() {
+        super("TntCountdown");
+
+        this.registerOptions(
+            TntCountdown.TNT_TICKS
+        );
+    }
+
+    @Override
+    public boolean isClientNotify() {
+        return true;
+    }
+
+    /**
+     * Set the amount of ticks before the specified TNT explodes.
+     *
+     * @param player the player
+     * @param entityId the entity id
+     * @param ticks the ticks
+     * @since 1.0.0
+     */
+    public abstract void setTntTicks(ApolloPlayer player, int entityId, int ticks);
+
+}

--- a/bukkit/plugin/src/main/java/com/lunarclient/apollo/impl/bukkit/ApolloBukkitPlatform.java
+++ b/bukkit/plugin/src/main/java/com/lunarclient/apollo/impl/bukkit/ApolloBukkitPlatform.java
@@ -27,6 +27,8 @@ import com.lunarclient.apollo.module.type.Teams;
 import com.lunarclient.apollo.module.type.TeamsImpl;
 import com.lunarclient.apollo.module.type.Titles;
 import com.lunarclient.apollo.module.type.TitlesImpl;
+import com.lunarclient.apollo.module.type.TntCountdown;
+import com.lunarclient.apollo.module.type.TntCountdownImpl;
 import com.lunarclient.apollo.module.type.Waypoints;
 import com.lunarclient.apollo.module.type.WaypointsImpl;
 import com.lunarclient.apollo.player.ApolloPlayerManagerImpl;
@@ -70,6 +72,7 @@ public final class ApolloBukkitPlatform extends JavaPlugin implements ApolloPlat
                 .addModule(Stopwatch.class, new StopwatchImpl())
                 .addModule(Teams.class, new TeamsImpl())
                 .addModule(Titles.class, new TitlesImpl())
+                .addModule(TntCountdown.class, new TntCountdownImpl())
                 .addModule(Waypoints.class, new WaypointsImpl())
                 .addModule(LegacyCombat.class);
 

--- a/bukkit/plugin/src/main/java/com/lunarclient/apollo/impl/bukkit/listener/TntCountdownListener.java
+++ b/bukkit/plugin/src/main/java/com/lunarclient/apollo/impl/bukkit/listener/TntCountdownListener.java
@@ -1,0 +1,35 @@
+package com.lunarclient.apollo.impl.bukkit.listener;
+
+import com.lunarclient.apollo.Apollo;
+import com.lunarclient.apollo.module.type.TntCountdown;
+import com.lunarclient.apollo.player.ApolloPlayer;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntitySpawnEvent;
+
+@RequiredArgsConstructor
+public class TntCountdownListener implements Listener {
+    private final TntCountdown tntCountdownModule;
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onTntSpawn(final EntitySpawnEvent event) {
+        if(!(event.getEntity() instanceof final TNTPrimed primed)) return;
+        final int id = event.getEntity().getEntityId();
+        final int ticks = primed.getFuseTicks();
+
+        if(ticks != tntCountdownModule.getOptions().get(TntCountdown.TNT_TICKS)) {
+            for(final Player bukkitPlayer : event.getLocation().getNearbyPlayers(Bukkit.getSimulationDistance())) {
+                final Optional<ApolloPlayer> player = Apollo.getPlayerManager().getPlayer(bukkitPlayer.getUniqueId());
+                if(player.isEmpty()) continue;
+
+                tntCountdownModule.setTntTicks(player.get(), id, ticks);
+            }
+        }
+    }
+}

--- a/bukkit/v1_18/src/main/java/com/lunarclient/apollo/impl/bukkit/v1_18/mixin/PrimedTnt_v1_18.java
+++ b/bukkit/v1_18/src/main/java/com/lunarclient/apollo/impl/bukkit/v1_18/mixin/PrimedTnt_v1_18.java
@@ -1,0 +1,19 @@
+package com.lunarclient.apollo.impl.bukkit.v1_18.mixin;
+
+import com.lunarclient.apollo.Apollo;
+import com.lunarclient.apollo.module.type.TntCountdown;
+import net.minecraft.world.entity.item.PrimedTnt;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(PrimedTnt.class)
+public abstract class PrimedTnt_v1_18 {
+    @ModifyConstant(method = "<init>(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/entity/LivingEntity;)V", constant = @Constant(intValue = 80))
+    public int fuseTicks(int constant) {
+        return Apollo.getModuleManager()
+                .getModule(TntCountdown.class)
+                .flatMap(module -> module.getOptions().getDirect(TntCountdown.TNT_TICKS))
+                .orElse(constant);
+    }
+}

--- a/bukkit/v1_18/src/main/resources/mixins.apollo.v1_18.json
+++ b/bukkit/v1_18/src/main/resources/mixins.apollo.v1_18.json
@@ -5,10 +5,11 @@
   "required": true,
   "compatibilityLevel": "JAVA_11",
   "mixins": [
-    "PlayerMixin_v1_18",
     "LivingEntityMixin_v1_18",
-    "ThrownPotionMixin_v1_18",
-    "ServerGamePacketListenerImplMixin_v1_18"
+    "PlayerMixin_v1_18",
+    "PrimedTnt_v1_18",
+    "ServerGamePacketListenerImplMixin_v1_18",
+    "ThrownPotionMixin_v1_18"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/bukkit/v1_19/src/main/java/com/lunarclient/apollo/impl/bukkit/v1_19/mixin/PrimedTnt_v1_19.java
+++ b/bukkit/v1_19/src/main/java/com/lunarclient/apollo/impl/bukkit/v1_19/mixin/PrimedTnt_v1_19.java
@@ -1,0 +1,19 @@
+package com.lunarclient.apollo.impl.bukkit.v1_19.mixin;
+
+import com.lunarclient.apollo.Apollo;
+import com.lunarclient.apollo.module.type.TntCountdown;
+import net.minecraft.world.entity.item.PrimedTnt;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(PrimedTnt.class)
+public abstract class PrimedTnt_v1_19 {
+    @ModifyConstant(method = "<init>(Lnet/minecraft/world/level/Level;DDDLnet/minecraft/world/entity/LivingEntity;)V", constant = @Constant(intValue = 80))
+    public int fuseTicks(int constant) {
+        return Apollo.getModuleManager()
+            .getModule(TntCountdown.class)
+            .flatMap(module -> module.getOptions().getDirect(TntCountdown.TNT_TICKS))
+            .orElse(constant);
+    }
+}

--- a/bukkit/v1_19/src/main/resources/mixins.apollo.v1_19.json
+++ b/bukkit/v1_19/src/main/resources/mixins.apollo.v1_19.json
@@ -5,8 +5,9 @@
   "required": true,
   "compatibilityLevel": "JAVA_11",
   "mixins": [
-    "PlayerMixin_v1_19",
     "LivingEntityMixin_v1_19",
+    "PlayerMixin_v1_19",
+    "PrimedTnt_v1_19",
     "ServerGamePacketListenerImplMixin_v1_19"
   ],
   "injectors": {

--- a/common/src/main/java/com/lunarclient/apollo/module/type/TntCountdownImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/type/TntCountdownImpl.java
@@ -1,0 +1,30 @@
+package com.lunarclient.apollo.module.type;
+
+import com.lunarclient.apollo.player.AbstractApolloPlayer;
+import com.lunarclient.apollo.player.ApolloPlayer;
+import lunarclient.apollo.common.OptionOperation;
+import lunarclient.apollo.modules.TntCountdownMessage;
+
+import static java.util.Objects.requireNonNull;
+
+public final class TntCountdownImpl extends TntCountdown {
+
+    public TntCountdownImpl() {
+        super();
+    }
+
+    @Override
+    public void setTntTicks(ApolloPlayer player, int entityId, int ticks) {
+        requireNonNull(player, "player");
+
+        ((AbstractApolloPlayer) player).sendPacket(this, OptionOperation.SET, this.to(entityId, ticks));
+    }
+
+    private TntCountdownMessage to(int entityId, int ticks) {
+        return TntCountdownMessage.newBuilder()
+                .setEntityId(entityId)
+                .setTicks(ticks)
+                .build();
+    }
+
+}

--- a/common/src/main/proto/com/moonsworth/apollo/protocol/modules.proto
+++ b/common/src/main/proto/com/moonsworth/apollo/protocol/modules.proto
@@ -72,6 +72,11 @@ message StopwatchActionMessage {
     Action action = 1;
 }
 
+message TntCountdownMessage {
+    int32 entityId = 1;
+    int32 ticks = 2;
+}
+
 message ToggleArmorPartMessage {
   enum Part {
     HELMET = 0;


### PR DESCRIPTION
Adds a way to customize the tnt tick time in the configuration. The global tick time will get sent to the client as long as it's not the default. If the tick time is changed on a specific tnt entity using the likes of `TNTPrimed#setFuseTicks(int)`, the time for that tnt will also be sent to the client as long as it's not the global tnt tick time.