### PR TITLE
Fix a bug where the Comment Header was always being added in configs

### DIFF
--- a/common/src/main/java/com/lunarclient/apollo/module/ApolloModuleManagerImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/ApolloModuleManagerImpl.java
@@ -158,7 +158,6 @@ public final class ApolloModuleManagerImpl implements ApolloModuleManager {
                 ApolloConfig config = ApolloConfig.get(configTarget);
 
                 CommentedConfigurationNode node = config.node();
-
                 node.commentIfAbsent(configTarget.getHeaderComment());
 
                 CommentedConfigurationNode modules = node.node((Object[]) configTarget.getModulesNode());


### PR DESCRIPTION
Fixes a bug where every time a config was saved the header was added to the top even if it already existed