### PR TITLE
Feature - Title scale interpolation

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/module/title/Title.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/title/Title.java
@@ -85,4 +85,27 @@ public final class Title {
      */
     Duration fadeOutTime;
 
+    /**
+     * Returns the title {@link Float} interpolation scale.
+     *
+     * <p>If the provided interpolation scale is greater than {@link Title#scale},
+     * the title will expand. However, if the {@link Title#scale} is greater than
+     * the interpolation scale, the title will shrink.</p>
+     *
+     * @return the title interpolation scale
+     * @since 1.0.7
+     */
+    float interpolationScale;
+
+    /**
+     * Returns the title {@link Float} interpolation rate.
+     *
+     * <p>The rate that the title will expand or shrink every tick (50ms)
+     * between {@link Title#scale} and {@link Title#interpolationScale}.</p>
+     *
+     * @return the title interpolation rate
+     * @since 1.0.7
+     */
+    float interpolationRate;
+
 }

--- a/bukkit-example/src/main/java/com/lunarclient/apollo/example/modules/TitleExample.java
+++ b/bukkit-example/src/main/java/com/lunarclient/apollo/example/modules/TitleExample.java
@@ -52,6 +52,21 @@ public class TitleExample {
         .fadeOutTime(Duration.ofMillis(300))
         .build();
 
+    private final Title interpolatedTitle = Title.builder()
+        .type(TitleType.TITLE)
+        .message(Component.text()
+            .content("This title expands!")
+            .color(NamedTextColor.GREEN)
+            .decorate(TextDecoration.BOLD)
+            .build())
+        .scale(0.1f)
+        .interpolationScale(1.0f)
+        .interpolationRate(0.01f)
+        .displayTime(Duration.ofMillis(5000L))
+        .fadeInTime(Duration.ofMillis(250))
+        .fadeOutTime(Duration.ofMillis(300))
+        .build();
+
     public void displayTitleExample(Player viewer) {
         Optional<ApolloPlayer> apolloPlayerOpt = Apollo.getPlayerManager().getPlayer(viewer.getUniqueId());
         apolloPlayerOpt.ifPresent(apolloPlayer -> this.titleModule.displayTitle(apolloPlayer, this.helloTitle));

--- a/common/src/main/java/com/lunarclient/apollo/module/title/TitleModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/title/TitleModuleImpl.java
@@ -48,6 +48,8 @@ public final class TitleModuleImpl extends TitleModule {
             .setFadeInTime(NetworkTypes.toProtobuf(title.getFadeInTime()))
             .setDisplayTime(NetworkTypes.toProtobuf(title.getDisplayTime()))
             .setFadeOutTime(NetworkTypes.toProtobuf(title.getFadeOutTime()))
+            .setInterpolationScale(title.getInterpolationScale())
+            .setInterpolationRate(title.getInterpolationRate())
             .build();
 
         recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));

--- a/docs/developers/modules/title.mdx
+++ b/docs/developers/modules/title.mdx
@@ -33,6 +33,23 @@ private final Title helloTitle = Title.builder()
     .build();
 ```
 
+```java
+private final Title interpolatedTitle = Title.builder()
+    .type(TitleType.TITLE)
+    .message(Component.text()
+        .content("This title expands!")
+        .color(NamedTextColor.GREEN)
+        .decorate(TextDecoration.BOLD)
+        .build())
+    .scale(0.1f)
+    .interpolationScale(1.0f)
+    .interpolationRate(0.01f)
+    .displayTime(Duration.ofMillis(5000L))
+    .fadeInTime(Duration.ofMillis(250))
+    .fadeOutTime(Duration.ofMillis(300))
+    .build();
+```
+
 #### `Title` Options
 
 `.type(TitleType)` is the type of title you want to display. See the [TitleType](#titletype-types) types section for more.
@@ -73,6 +90,18 @@ private final Title helloTitle = Title.builder()
 
 ```java
 .fadeOutTime(Duration.ofMillis(300))
+```
+
+`.interpolationScale(Float)` if the provided interpolation scale is greater than the scale, the title will expand. However, if the scale is greater than the interpolation scale, the title will shrink.
+
+```java
+.interpolationScale(1.0f)
+```
+
+`.interpolationRate(Float)` is the rate that the title will expand or shrink every tick (50ms) between the scale and the interpolation scale.
+
+```java
+.interpolationRate(0.01f)
 ```
 
 ### Displaying a title for a player


### PR DESCRIPTION
**Overview**
This PR adds two properties to the `Title` class:

1. `interpolationScale`
   - Allows the title to dynamically expand or shrink based on the provided scale.
   - If the scale exceeds the current `Title#scale`, the title expands; otherwise, it shrinks.

2. `interpolationRate`
   - Controls the speed of title expansion or shrinkage.
   - Defines the rate at which the title adjusts its size every _tick_ (50ms) between the current `scale` and the target `interpolationScale`.

**Example**

In the provided example, the title scale starts small at `0.1` and gradually increases by `0.01` every tick until reaching `1.0` or the title expires.

```java
Title interpolatedTitle = Title.builder()
        .type(TitleType.TITLE)
        .message(Component.text()
            .content("This title expands!")
            .color(NamedTextColor.GREEN)
            .decorate(TextDecoration.BOLD)
            .build())
        .scale(0.1f)
        .interpolationScale(1.0f)
        .interpolationRate(0.01f)
        .displayTime(Duration.ofMillis(5000L))
        .fadeInTime(Duration.ofMillis(250))
        .fadeOutTime(Duration.ofMillis(300))
        .build();
```