### PR TITLE
Publish version branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
                 fi
 
         -   name: Gradle Publish
-            if: "${{ github.ref == 'refs/heads/master' }}"
+            if: "${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/version/') }}"
             run: ./gradlew publish
 
         -   name: Gradle Release


### PR DESCRIPTION
**Description**
Allows publishing on branches prefixed with `version/`

This will be used for releasing future versions of Apollo. Rather than merging pull requests directly into **master**, we merge to a designated **version** branch first.