### PR TITLE
Add Issue & Pull Request Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -16,7 +16,7 @@ body:
     - type: checkboxes
       id: confirmation
       attributes:
-          label: Checklist before creating an issue;
+          label: "Checklist before creating an issue:"
           description: Verify your setup before creating the issue.
           options:
               - label: I'm using the [latest version](https://github.com/LunarClient/Apollo/releases) of Apollo.
@@ -46,7 +46,7 @@ body:
       attributes:
           label: "Reproduction steps"
           description: Please enter an explicit description of the issue.
-          value: |
+          placeholder: |
               1. Go to '...'
               2. Click on '....'
               3. Scroll down to '....'
@@ -130,7 +130,7 @@ body:
       attributes:
           label: "Screenshots"
           description: If applicable, add screenshots to help explain your problem.
-          value: |
+          placeholder: |
               ![DESCRIPTION](LINK.png)
           render: bash
       validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,161 @@
+name: "🐛 Bug Report"
+description: Create an issue to report a bug with Apollo.
+title: "[Bug Report] <title>"
+labels: [
+    "status: Pending",
+    "type: Bug"
+]
+body:
+    # Intro
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to report this issue, if you want to request a feature join our [Discord](https://discord.gg/3T9Atyb6pf).
+
+    # Checklist
+    - type: checkboxes
+      id: confirmation
+      attributes:
+          label: Checklist before creating an issue;
+          description: Verify your setup before creating the issue.
+          options:
+              - label: I'm using the [latest version](https://github.com/LunarClient/Apollo/releases) of Apollo.
+                required: true
+              - label: I'm using the latest version of Lunar Client. (Relaunched in the last hour)
+                required: true
+              - label: I'm running Apollo on **ONLY** the backend server OR the proxy. **(YOU CANNOT RUN IT ON BOTH)**
+                required: true
+              - label: I do **NOT** have both Apollo and the LEGACY API installed on the same server. **(YOU CANNOT RUN BOTH AT THE SAME TIME)**
+                required: true
+              - label: I've gathered all screenshots, logs and appropriate information related to creating a bug report.
+                required: true
+
+    # Description
+    - type: textarea
+      id: description
+      attributes:
+          label: "Issue Description"
+          description: Please enter an explicit description of the issue.
+          placeholder: Short and explicit description of your incident...
+      validations:
+          required: true
+
+    # Reproduction steps
+    - type: textarea
+      id: reprod
+      attributes:
+          label: "Reproduction steps"
+          description: Please enter an explicit description of the issue.
+          value: |
+              1. Go to '...'
+              2. Click on '....'
+              3. Scroll down to '....'
+              4. See error
+          render: bash
+      validations:
+          required: true
+
+    # Lunar Client Version(s)
+    - type: dropdown
+      id: versions
+      attributes:
+          label: "Versions"
+          description: What Minecraft versions are you experiencing the problem on?
+          multiple: true
+          options:
+              - 1.7
+              - 1.8
+              - 1.12
+              - 1.16
+              - 1.17
+              - 1.18
+              - 1.19
+              - 1.20+
+      validations:
+          required: true
+
+    # Server Platform(s)
+    - type: dropdown
+      id: platforms
+      attributes:
+          label: "Platforms"
+          description: What server platform are you experiencing the problem on?
+          multiple: true
+          options:
+              - Spigot / Bukkit
+              - BungeeCord
+              - Velocity
+              - Other
+      validations:
+          required: true
+
+    # Server Version(s)
+    - type: dropdown
+      id: serverversions
+      attributes:
+          label: "Server Version"
+          description: What is the primary version your server is on?
+          multiple: false
+          options:
+              - 1.7
+              - 1.8
+              - 1.12
+              - 1.16
+              - 1.17
+              - 1.18
+              - 1.19
+              - 1.20+
+              - Other/Not Listed
+      validations:
+          required: true
+
+    # Lunar Client Modules
+    - type: dropdown
+      id: modules
+      attributes:
+          label: "Modules"
+          description: What Lunar Client modules are you experiencing the problem on?
+          multiple: true
+          options:
+              - "Sodium"
+              - "Optifine"
+              - "Forge"
+              - "Fabric"
+      validations:
+          required: false
+
+    # Screenshots
+    - type: textarea
+      id: screenshot
+      attributes:
+          label: "Screenshots"
+          description: If applicable, add screenshots to help explain your problem.
+          value: |
+              ![DESCRIPTION](LINK.png)
+          render: bash
+      validations:
+          required: false
+
+    # Form of Contact
+    - type: textarea
+      id: contact
+      attributes:
+          label: "Contact Information"
+          description: Please enter the best way to get into contact with you. (Preferably your Discord)
+          placeholder: |
+              Discord - JohnDoe
+              Telegram - JohnDoe
+              Email - email@moonsworth.com
+          render: bash
+      validations:
+          required: true
+
+    # Additional Context
+    - type: textarea
+      id: context
+      attributes:
+          label: "Additional Context"
+          description: Do you have anything to say that cannot be covered by the questions above?
+          placeholder: ...
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+    - name: ❓ Questions & Feature Request
+      url: https://discord.gg/3T9Atyb6pf
+      about: Join our Discord to ask question and request features for Apollo.
+    - name: 📄 Documentation
+      url: https://lunarclient.dev/apollo/introduction
+      about: Visit our documentation page to understand Apollo better.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
     - name: ❓ Questions & Feature Request
       url: https://discord.gg/3T9Atyb6pf
-      about: Join our Discord to ask question and request features for Apollo.
+      about: Join our Discord to ask questions and request features for Apollo.
     - name: 📄 Documentation
       url: https://lunarclient.dev/apollo/introduction
       about: Visit our documentation page to understand Apollo better.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Overview
+
+**Description:**
+<!--- Provide a general summary of your changes -->
+
+**Changes:**
+<!--- Describe your changes in detail -->
+
+**Code Example (If applicable):**
+```java
+
+```
+
+**Related Issue (If applicable):**
+<!--- Link related issues here -->
+
+**Screenshots and/or Videos (If applicable):**
+<!--- Provide any Screenshots and/or Videos -->
+
+---
+
+## Review Request Checklist
+
+- [ ] Your code follows the style guidelines of this project.
+- [ ] I have performed a self-review of my code.
+- [ ] I have tested this change myself. (If applicable)
+- [ ] I have made corresponding changes to the documentation. (If applicable)
+- [ ] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)
+
+
+---


### PR DESCRIPTION
Adds a config file to create this selection menu, after clicking 'New Issue'.
![68b0feb64cf02e7644b31651a13946e9](https://github.com/LunarClient/Apollo/assets/25537885/1d710791-9313-4fb8-ab35-f60cee4ae7f5)

After clicking 'Get Started' on the 'Bug Report' option you're then prompted with a form, which can be viewed below, hopefully a form will help keep everything organized while providing more clarity on certain issues. Using the form will also automatically apply the status label 'Pending' and type label 'Bug'.
![47f0b896f1d3a10d30ba34427127fce5](https://github.com/LunarClient/Apollo/assets/25537885/028e16c3-49d9-4542-8bc8-9520d3fabdd9)

Lastly, we have the PR template. It adds text to the description of PRs to ensure everything is in order before opening the PR.
![a2f37fb6219ffc07298790a480fae01f](https://github.com/LunarClient/Apollo/assets/25537885/686f3446-1668-4cb4-b55f-83a1a5bd4c79)
