### PR TITLE
Feature - LunarClient Command

### DIFF
--- a/bukkit/src/main/java/com/lunarclient/apollo/ApolloBukkitPlatform.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/ApolloBukkitPlatform.java
@@ -23,7 +23,8 @@
  */
 package com.lunarclient.apollo;
 
-import com.lunarclient.apollo.command.ApolloCommand;
+import com.lunarclient.apollo.command.impl.ApolloCommand;
+import com.lunarclient.apollo.command.impl.LunarClientCommand;
 import com.lunarclient.apollo.listener.ApolloPlayerListener;
 import com.lunarclient.apollo.listener.ApolloWorldListener;
 import com.lunarclient.apollo.loader.PlatformPlugin;
@@ -151,7 +152,8 @@ public final class ApolloBukkitPlatform implements PlatformPlugin, ApolloPlatfor
             (channel, player, bytes) -> ApolloManager.getNetworkManager().receivePacket(player.getUniqueId(), bytes)
         );
 
-        this.getPlugin().getCommand("apollo").setExecutor(new ApolloCommand());
+        this.plugin.getCommand("apollo").setExecutor(new ApolloCommand());
+        this.plugin.getCommand("lunarclient").setExecutor(new LunarClientCommand());
 
         statsManager.enable();
         versionManager.checkForUpdates();

--- a/bukkit/src/main/java/com/lunarclient/apollo/command/BukkitApolloCommand.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/command/BukkitApolloCommand.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.command;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import lombok.NonNull;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ * Provides common command functions for Bukkit.
+ *
+ * @param <T> the sender type
+ * @since 1.0.9
+ */
+public abstract class BukkitApolloCommand<T> extends AbstractApolloCommand<T> {
+
+    /**
+     * Returns a new instance of a Bukkit command.
+     *
+     * @param textConsumer the consumer for sending messages to the sender
+     * @since 1.0.9
+     */
+    public BukkitApolloCommand(BiConsumer<T, Component> textConsumer) {
+        super(textConsumer);
+    }
+
+    /**
+     * Handles a player argument; if the provided player doesn't exist, a not found message
+     * is sent to the sender. Otherwise, the player is passed to the provided player consumer.
+     *
+     * @param sender the command sender
+     * @param argument the argument passed from the command execution
+     * @param playerConsumer a consumer used for processing a desired action if the player is found
+     * @since 1.0.9
+     */
+    protected void handlePlayerArgument(@NonNull T sender, @NonNull String argument, @NonNull Consumer<Player> playerConsumer) {
+        Player player = Bukkit.getPlayer(argument);
+
+        if (player == null) {
+            this.textConsumer.accept(sender, Component.text("Player '", NamedTextColor.RED)
+                .append(Component.text(argument, NamedTextColor.RED))
+                .append(Component.text("' not found!", NamedTextColor.RED)));
+            return;
+        }
+
+        playerConsumer.accept(player);
+    }
+}

--- a/bukkit/src/main/java/com/lunarclient/apollo/command/impl/ApolloCommand.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/command/impl/ApolloCommand.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.command.impl;
+
+import com.lunarclient.apollo.command.BukkitApolloCommand;
+import com.lunarclient.apollo.common.ApolloComponent;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+/**
+ * The general Apollo command.
+ *
+ * @since 1.0.5
+ */
+public final class ApolloCommand extends BukkitApolloCommand<CommandSender> implements CommandExecutor {
+
+    /**
+     * Returns a new instance of this command.
+     *
+     * @since 1.0.5
+     */
+    public ApolloCommand() {
+        super((sender, component) -> sender.sendMessage(ApolloComponent.toLegacy(component)));
+    }
+
+    @Override
+    public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
+        if(args.length < 1) {
+            this.getCurrentVersion(commandSender);
+        } else if(args[0].equalsIgnoreCase("reload")) {
+            this.reloadConfiguration(commandSender);
+        }
+
+        return true;
+    }
+
+}

--- a/bukkit/src/main/java/com/lunarclient/apollo/command/impl/LunarClientCommand.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/command/impl/LunarClientCommand.java
@@ -21,35 +21,52 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.lunarclient.apollo.command;
+package com.lunarclient.apollo.command.impl;
 
+import com.lunarclient.apollo.Apollo;
+import com.lunarclient.apollo.command.BukkitApolloCommand;
 import com.lunarclient.apollo.common.ApolloComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 
 /**
- * The general Apollo command.
+ * The general Lunar Client command.
  *
- * @since 1.0.5
+ * @since 1.0.9
  */
-public final class ApolloCommand extends AbstractApolloCommand<CommandSender> implements CommandExecutor {
+public final class LunarClientCommand extends BukkitApolloCommand<CommandSender> implements CommandExecutor {
 
     /**
      * Returns a new instance of this command.
      *
-     * @since 1.0.5
+     * @since 1.0.9
      */
-    public ApolloCommand() {
+    public LunarClientCommand() {
         super((sender, component) -> sender.sendMessage(ApolloComponent.toLegacy(component)));
     }
 
     @Override
     public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
-        if(args.length < 1) {
-            this.getCurrentVersion(commandSender);
-        } else if(args[0].equalsIgnoreCase("reload")) {
-            this.reloadConfiguration(commandSender);
+        if(args.length != 1) {
+            this.sendCommandUsage(commandSender, command.getUsage());
+        } else {
+            this.handlePlayerArgument(commandSender, args[0], player -> {
+                Component message = Component.text("Player ", NamedTextColor.YELLOW)
+                    .append(Component.text(player.getDisplayName()));
+
+                if (Apollo.getPlayerManager().hasSupport(player.getUniqueId())) {
+                    message = message.append(Component.text(" is using ", NamedTextColor.GREEN));
+                } else {
+                    message = message.append(Component.text(" is not using ", NamedTextColor.RED));
+                }
+
+                message = message.append(Component.text("LunarClient!", NamedTextColor.YELLOW));
+
+                this.textConsumer.accept(commandSender, message);
+            });
         }
 
         return true;

--- a/bukkit/src/main/java/com/lunarclient/apollo/command/impl/LunarClientCommand.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/command/impl/LunarClientCommand.java
@@ -46,12 +46,14 @@ public final class LunarClientCommand extends BukkitApolloCommand<CommandSender>
      */
     public LunarClientCommand() {
         super((sender, component) -> sender.sendMessage(ApolloComponent.toLegacy(component)));
+
+        this.setUsage("/lunarclient <player>");
     }
 
     @Override
     public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
         if(args.length != 1) {
-            this.sendCommandUsage(commandSender, command.getUsage());
+            this.sendCommandUsage(commandSender);
             return true;
         }
 
@@ -61,13 +63,12 @@ public final class LunarClientCommand extends BukkitApolloCommand<CommandSender>
                 .append(Component.text(" is ", NamedTextColor.GRAY));
 
             if (Apollo.getPlayerManager().hasSupport(player.getUniqueId())) {
-                message = message.append(Component.text(" using ", NamedTextColor.GREEN));
+                message = message.append(Component.text("using ", NamedTextColor.GREEN));
             } else {
-                message = message.append(Component.text(" not using ", NamedTextColor.RED));
+                message = message.append(Component.text("not using ", NamedTextColor.RED));
             }
 
             message = message.append(Component.text("Lunar Client!", NamedTextColor.GRAY));
-
             this.textConsumer.accept(commandSender, message);
         });
 

--- a/bukkit/src/platform-loader/resources/plugin.yml
+++ b/bukkit/src/platform-loader/resources/plugin.yml
@@ -10,3 +10,8 @@ commands:
     description: The main Apollo command.
     usage: /apollo <reload>
     permission: apollo.command
+  lunarclient:
+    aliases: [lc]
+    description: The command to check whether the player is using Lunar Client.
+    usage: /lunarclient <player>
+    permission: apollo.lunarclient

--- a/bungee/src/main/java/com/lunarclient/apollo/ApolloBungeePlatform.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/ApolloBungeePlatform.java
@@ -23,7 +23,8 @@
  */
 package com.lunarclient.apollo;
 
-import com.lunarclient.apollo.command.ApolloCommand;
+import com.lunarclient.apollo.command.impl.ApolloCommand;
+import com.lunarclient.apollo.command.impl.LunarClientCommand;
 import com.lunarclient.apollo.listener.ApolloPlayerListener;
 import com.lunarclient.apollo.loader.PlatformPlugin;
 import com.lunarclient.apollo.module.ApolloModuleManagerImpl;
@@ -76,6 +77,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.PluginManager;
 
 /**
  * The Bungee platform plugin.
@@ -133,8 +135,11 @@ public final class ApolloBungeePlatform implements PlatformPlugin, ApolloPlatfor
 
         ProxyServer server = this.plugin.getProxy();
         server.registerChannel(ApolloManager.PLUGIN_MESSAGE_CHANNEL);
-        server.getPluginManager().registerListener(this.plugin, new ApolloPlayerListener());
-        server.getPluginManager().registerCommand(this.plugin, ApolloCommand.create());
+
+        PluginManager pluginManager = server.getPluginManager();
+        pluginManager.registerListener(this.plugin, new ApolloPlayerListener());
+        pluginManager.registerCommand(this.plugin, ApolloCommand.create());
+        pluginManager.registerCommand(this.plugin, LunarClientCommand.create());
 
         statsManager.enable();
         versionManager.checkForUpdates();

--- a/bungee/src/main/java/com/lunarclient/apollo/command/BungeeApolloCommand.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/command/BungeeApolloCommand.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.command;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import lombok.NonNull;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+
+/**
+ * Provides common command functions for Bungee.
+ *
+ * @param <T> the sender type
+ * @since 1.0.9
+ */
+public abstract class BungeeApolloCommand<T> extends AbstractApolloCommand<T> {
+
+    /**
+     * Returns a new instance of a Bungee command.
+     *
+     * @param textConsumer the consumer for sending messages to the sender
+     * @since 1.0.9
+     */
+    public BungeeApolloCommand(BiConsumer<T, Component> textConsumer) {
+        super(textConsumer);
+    }
+
+    /**
+     * Handles a player argument; if the provided player doesn't exist, a not found message
+     * is sent to the sender. Otherwise, the player is passed to the provided player consumer.
+     *
+     * @param sender the command sender
+     * @param argument the argument passed from the command execution
+     * @param playerConsumer a consumer used for processing a desired action if the player is found
+     * @since 1.0.9
+     */
+    protected void handlePlayerArgument(@NonNull T sender, @NonNull String argument, @NonNull Consumer<ProxiedPlayer> playerConsumer) {
+        ProxiedPlayer player = ProxyServer.getInstance().getPlayer(argument);
+
+        if (player == null) {
+            this.textConsumer.accept(sender, Component.text("Player '", NamedTextColor.RED)
+                .append(Component.text(argument, NamedTextColor.RED))
+                .append(Component.text("' not found!", NamedTextColor.RED)));
+            return;
+        }
+
+        playerConsumer.accept(player);
+    }
+}

--- a/bungee/src/main/java/com/lunarclient/apollo/command/impl/ApolloCommand.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/command/impl/ApolloCommand.java
@@ -52,7 +52,7 @@ public final class ApolloCommand extends BungeeApolloCommand<CommandSender> {
         };
     }
 
-    public ApolloCommand() {
+    ApolloCommand() {
         super((sender, component) -> sender.sendMessage(ApolloComponent.toLegacy(component)));
     }
 

--- a/bungee/src/main/java/com/lunarclient/apollo/command/impl/ApolloCommand.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/command/impl/ApolloCommand.java
@@ -21,8 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.lunarclient.apollo.command;
+package com.lunarclient.apollo.command.impl;
 
+import com.lunarclient.apollo.command.BungeeApolloCommand;
 import com.lunarclient.apollo.common.ApolloComponent;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
@@ -32,7 +33,7 @@ import net.md_5.bungee.api.plugin.Command;
  *
  * @since 1.0.5
  */
-public final class ApolloCommand extends AbstractApolloCommand<CommandSender> {
+public final class ApolloCommand extends BungeeApolloCommand<CommandSender> {
 
     /**
      * Returns a new instance of this command.
@@ -51,7 +52,7 @@ public final class ApolloCommand extends AbstractApolloCommand<CommandSender> {
         };
     }
 
-    ApolloCommand() {
+    public ApolloCommand() {
         super((sender, component) -> sender.sendMessage(ApolloComponent.toLegacy(component)));
     }
 

--- a/bungee/src/main/java/com/lunarclient/apollo/command/impl/LunarClientCommand.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/command/impl/LunarClientCommand.java
@@ -24,20 +24,38 @@
 package com.lunarclient.apollo.command.impl;
 
 import com.lunarclient.apollo.Apollo;
-import com.lunarclient.apollo.command.BukkitApolloCommand;
+import com.lunarclient.apollo.command.BungeeApolloCommand;
 import com.lunarclient.apollo.common.ApolloComponent;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.plugin.Command;
 
 /**
  * The general Lunar Client command.
  *
  * @since 1.0.9
  */
-public final class LunarClientCommand extends BukkitApolloCommand<CommandSender> implements CommandExecutor {
+public final class LunarClientCommand extends BungeeApolloCommand<CommandSender> {
+
+
+    /**
+     * Returns a new instance of this command.
+     *
+     * @return a new command
+     * @since 1.0.9
+     */
+    public static Command create() {
+        return new Command("lunarclient", "apollo.lunarclient") {
+            private final LunarClientCommand command = new LunarClientCommand();
+
+            @Override
+            public void execute(CommandSender sender, String[] args) {
+                this.command.execute(sender, args);
+            }
+        };
+    }
+
 
     /**
      * Returns a new instance of this command.
@@ -48,14 +66,13 @@ public final class LunarClientCommand extends BukkitApolloCommand<CommandSender>
         super((sender, component) -> sender.sendMessage(ApolloComponent.toLegacy(component)));
     }
 
-    @Override
-    public boolean onCommand(CommandSender commandSender, Command command, String label, String[] args) {
+    void execute(CommandSender sender, String[] args) {
         if(args.length != 1) {
-            this.sendCommandUsage(commandSender, command.getUsage());
-            return true;
+            this.sendCommandUsage(sender, command.getUsage());
+            return;
         }
 
-        this.handlePlayerArgument(commandSender, args[0], player -> {
+        this.handlePlayerArgument(sender, args[0], player -> {
             Component message = Component.text("Player ", NamedTextColor.GRAY)
                 .append(Component.text(player.getName(), NamedTextColor.AQUA))
                 .append(Component.text(" is ", NamedTextColor.GRAY));
@@ -68,10 +85,8 @@ public final class LunarClientCommand extends BukkitApolloCommand<CommandSender>
 
             message = message.append(Component.text("Lunar Client!", NamedTextColor.GRAY));
 
-            this.textConsumer.accept(commandSender, message);
+            this.textConsumer.accept(sender, message);
         });
-
-        return true;
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/command/AbstractApolloCommand.java
+++ b/common/src/main/java/com/lunarclient/apollo/command/AbstractApolloCommand.java
@@ -30,6 +30,7 @@ import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
@@ -39,10 +40,13 @@ import net.kyori.adventure.text.format.NamedTextColor;
  * @param <T> the sender type
  * @since 1.0.5
  */
+@Setter
 @RequiredArgsConstructor
 public abstract class AbstractApolloCommand<T> {
 
     protected final BiConsumer<T, Component> textConsumer;
+
+    protected String usage;
 
     /**
      * Sends the current version message to the sender.
@@ -89,12 +93,11 @@ public abstract class AbstractApolloCommand<T> {
      * Sends the command usage to the sender.
      *
      * @param sender the command sender
-     * @param usage the command usage
      * @since 1.0.9
      */
-    protected void sendCommandUsage(@NonNull T sender, @NonNull String usage) {
+    protected void sendCommandUsage(@NonNull T sender) {
         this.textConsumer.accept(sender, Component.text("Usage: ", NamedTextColor.RED)
-            .append(Component.text(usage, NamedTextColor.RED)));
+            .append(Component.text(this.usage, NamedTextColor.RED)));
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/command/AbstractApolloCommand.java
+++ b/common/src/main/java/com/lunarclient/apollo/command/AbstractApolloCommand.java
@@ -42,7 +42,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 @RequiredArgsConstructor
 public abstract class AbstractApolloCommand<T> {
 
-    private final BiConsumer<T, Component> textConsumer;
+    protected final BiConsumer<T, Component> textConsumer;
 
     /**
      * Sends the current version message to the sender.
@@ -83,6 +83,18 @@ public abstract class AbstractApolloCommand<T> {
             "Reloaded the Apollo configuration!",
             NamedTextColor.GREEN
         ));
+    }
+
+    /**
+     * Sends the command usage to the sender.
+     *
+     * @param sender the command sender
+     * @param usage the command usage
+     * @since 1.0.9
+     */
+    protected void sendCommandUsage(@NonNull T sender, @NonNull String usage) {
+        this.textConsumer.accept(sender, Component.text("Usage: ", NamedTextColor.RED)
+            .append(Component.text(usage, NamedTextColor.RED)));
     }
 
 }

--- a/docs/server-owners/commands.mdx
+++ b/docs/server-owners/commands.mdx
@@ -12,3 +12,9 @@ Apollo comes with some built-in commands to make your life easier.
 * `/apollo reload`
     * Description: Reload The Apollo Configuration Files.
     * Permission: `apollo.command`
+
+
+* `/lunarclient <player>`
+    * Description: The command to check whether the player is using Lunar Client.
+    * Aliases: `lc`
+    * Permission: `apollo.lunarclient`

--- a/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
@@ -25,6 +25,7 @@ package com.lunarclient.apollo;
 
 import com.google.inject.Inject;
 import com.lunarclient.apollo.command.impl.ApolloCommand;
+import com.lunarclient.apollo.command.impl.LunarClientCommand;
 import com.lunarclient.apollo.listener.ApolloPlayerListener;
 import com.lunarclient.apollo.module.ApolloModuleManagerImpl;
 import com.lunarclient.apollo.module.beam.BeamModule;
@@ -70,6 +71,7 @@ import com.lunarclient.apollo.stats.ApolloStats;
 import com.lunarclient.apollo.stats.ApolloStatsManager;
 import com.lunarclient.apollo.version.ApolloVersionManager;
 import com.lunarclient.apollo.wrapper.VelocityApolloStats;
+import com.velocitypowered.api.command.CommandManager;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
@@ -192,7 +194,9 @@ public final class ApolloVelocityPlatform implements ApolloPlatform {
         this.server.getEventManager().register(this, new ApolloPlayerListener());
         this.server.getChannelRegistrar().register(ApolloVelocityPlatform.PLUGIN_CHANNEL);
 
-        this.server.getCommandManager().register(ApolloCommand.create());
+        CommandManager commandManager = this.server.getCommandManager();
+        commandManager.register(ApolloCommand.create());
+        commandManager.register(LunarClientCommand.create());
 
         statsManager.enable();
         versionManager.checkForUpdates();

--- a/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
@@ -24,7 +24,7 @@
 package com.lunarclient.apollo;
 
 import com.google.inject.Inject;
-import com.lunarclient.apollo.command.ApolloCommand;
+import com.lunarclient.apollo.command.impl.ApolloCommand;
 import com.lunarclient.apollo.listener.ApolloPlayerListener;
 import com.lunarclient.apollo.module.ApolloModuleManagerImpl;
 import com.lunarclient.apollo.module.beam.BeamModule;

--- a/velocity/src/main/java/com/lunarclient/apollo/command/VelocityApolloCommand.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/command/VelocityApolloCommand.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.command;
+
+import com.lunarclient.apollo.ApolloVelocityPlatform;
+import com.velocitypowered.api.proxy.Player;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import lombok.NonNull;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * Provides common command functions for Velocity.
+ *
+ * @param <T> the sender type
+ * @since 1.0.9
+ */
+public abstract class VelocityApolloCommand<T> extends AbstractApolloCommand<T> {
+
+    /**
+     * Returns a new instance of a Velocity command.
+     *
+     * @param textConsumer the consumer for sending messages to the sender
+     * @since 1.0.9
+     */
+    public VelocityApolloCommand(BiConsumer<T, Component> textConsumer) {
+        super(textConsumer);
+    }
+
+    /**
+     * Handles a player argument; if the provided player doesn't exist, a not found message
+     * is sent to the sender. Otherwise, the player is passed to the provided player consumer.
+     *
+     * @param sender the command sender
+     * @param argument the argument passed from the command execution
+     * @param playerConsumer a consumer used for processing a desired action if the player is found
+     * @since 1.0.9
+     */
+    protected void handlePlayerArgument(@NonNull T sender, @NonNull String argument, @NonNull Consumer<Player> playerConsumer) {
+        Optional<Player> playerOpt = ApolloVelocityPlatform.getInstance().getServer().getPlayer(argument);
+
+        if (!playerOpt.isPresent()) {
+            this.textConsumer.accept(sender, Component.text("Player '", NamedTextColor.RED)
+                .append(Component.text(argument, NamedTextColor.RED))
+                .append(Component.text("' not found!", NamedTextColor.RED)));
+            return;
+        }
+
+        playerConsumer.accept(playerOpt.get());
+    }
+}

--- a/velocity/src/main/java/com/lunarclient/apollo/command/impl/ApolloCommand.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/command/impl/ApolloCommand.java
@@ -21,8 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.lunarclient.apollo.command;
+package com.lunarclient.apollo.command.impl;
 
+import com.lunarclient.apollo.command.VelocityApolloCommand;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.velocitypowered.api.command.BrigadierCommand;
@@ -36,7 +37,7 @@ import net.kyori.adventure.audience.Audience;
  * @since 1.0.5
  */
 @Getter
-public final class ApolloCommand extends AbstractApolloCommand<CommandSource> {
+public final class ApolloCommand extends VelocityApolloCommand<CommandSource> {
 
     /**
      * Returns a new instance of this command.


### PR DESCRIPTION
## Overview

**Description:**
Add `/lunarclient` command to check if a player is _using_ Lunar Client.

**Changes:**
Other than adding the LunarClient command, I made some small improvements to the Apollo command system which included adding a respected implementation for each platform (e.g. `BukkitApolloCommand`) which implements a method for handling a player argument easily.

**Screenshots and/or Videos (If applicable):**
<!--- Provide any Screenshots and/or Videos -->
![image](https://github.com/LunarClient/Apollo/assets/29950356/1377bd05-0064-4a0d-a69c-5413f3b6ace9)

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
