### PR TITLE
Fix - Hologram example typo

### DIFF
--- a/bukkit-example/src/main/java/com/lunarclient/apollo/example/modules/HologramExample.java
+++ b/bukkit-example/src/main/java/com/lunarclient/apollo/example/modules/HologramExample.java
@@ -45,7 +45,7 @@ public class HologramExample {
             .id("welcome-hologram")
             .location(ApolloLocation.builder()
                 .world("world")
-                .z(5)
+                .x(5)
                 .y(105)
                 .z(0)
                 .build())

--- a/docs/developers/modules/hologram.mdx
+++ b/docs/developers/modules/hologram.mdx
@@ -20,7 +20,7 @@ public void displayHologramExample() {
         .id("welcome-hologram")
         .location(ApolloLocation.builder()
             .world("world")
-            .z(5)
+            .x(5)
             .y(105)
             .z(0)
             .build())
@@ -55,7 +55,7 @@ public void displayHologramExample() {
 ```java
 .location(ApolloLocation.builder()
     .world("world")
-    .z(5)
+    .x(5)
     .y(100)
     .z(0)
     .build()


### PR DESCRIPTION
## Overview

**Description:**
Fixes a typo for the hologram example location.

**Changes:**
Changes one of the `z` coordinates to an `x` coordinate, since there were two `z` coordinates.

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
