### PR TITLE
Allow releases on version branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
             run: ./gradlew publish
 
         -   name: Gradle Release
-            if: "${{ github.ref == 'refs/heads/master' && env.STATUS == 'release' }}"
+            if: "${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/version/')) && env.STATUS == 'release' }}"
             uses: softprops/action-gh-release@v1
             with:
                 draft: false


### PR DESCRIPTION
## Overview

**Description:**
Allows GitHub releases to be created on the branches that start with `version/`.

**Changes**
While releasing version `1.0.9`, we encountered an issue wherein the deployment process failed after merging the `version/1.0.9` branch into `master`. This occurred because the deployment had already successfully run on the `version/` branch, which was marked for release. This code will fix it by allowing the `version/` branch to create the release.

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
