### PR TITLE
Ignore TNT spawned with a custom fuse duration

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/module/tntcountdown/TntCountdownModule.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/tntcountdown/TntCountdownModule.java
@@ -27,6 +27,7 @@ import com.lunarclient.apollo.common.ApolloEntity;
 import com.lunarclient.apollo.module.ApolloModule;
 import com.lunarclient.apollo.module.ModuleDefinition;
 import com.lunarclient.apollo.option.NumberOption;
+import com.lunarclient.apollo.option.SimpleOption;
 import io.leangen.geantyref.TypeToken;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Range;
@@ -51,9 +52,20 @@ public abstract class TntCountdownModule extends ApolloModule {
         .defaultValue(80).min(1).max(Integer.MAX_VALUE)
         .notifyClient().build();
 
+    /**
+     * Whether to override the amount of ticks for TNT ignited by a plugin.
+     *
+     * @since 1.1.0
+     */
+    public static final SimpleOption<Boolean> OVERRIDE_CUSTOM_TICKS = SimpleOption.<Boolean>builder()
+        .comment("Whether to override custom TNT explosion ticks.")
+        .node("override-custom-ticks").type(TypeToken.get(Boolean.class))
+        .defaultValue(false).notifyClient().build();
+
     TntCountdownModule() {
         this.registerOptions(
-            TntCountdownModule.TNT_TICKS
+            TntCountdownModule.TNT_TICKS,
+            TntCountdownModule.OVERRIDE_CUSTOM_TICKS
         );
     }
 

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -9,6 +9,7 @@ setupDynamicDependency("adventure4", "shadowJarAdventure4", "adventure/4/", "dep
 
 dependencies {
     compileOnly(libs.bukkit)
+    compileOnly(libs.protobuf)
 
     api(project(path = ":apollo-api", configuration = "shadow"))
     api(project(path = ":apollo-common", configuration = "shadow"))

--- a/bukkit/src/main/java/com/lunarclient/apollo/module/tntcountdown/TntCountdownModuleImpl.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/module/tntcountdown/TntCountdownModuleImpl.java
@@ -103,20 +103,29 @@ public final class TntCountdownModuleImpl extends TntCountdownModule implements 
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     private void onTntSpawn(EntitySpawnEvent event) {
-        // We only care about TNT
         if (event.getEntityType() != EntityType.PRIMED_TNT) {
             return;
         }
 
         TNTPrimed primed = (TNTPrimed) event.getEntity();
-        int customFuse = this.getOptions().get(TntCountdownModule.TNT_TICKS);
+        int customTicks = this.getOptions().get(TntCountdownModule.TNT_TICKS);
+        int defaultTicks = TntCountdownModule.TNT_TICKS.getDefaultValue();
+        int currentTicks = primed.getFuseTicks();
 
-        // We only care about TNT with a non-standard fuse as well.
-        if (primed.getFuseTicks() == customFuse) {
-            return;
+        if (currentTicks != defaultTicks && !this.getOptions().get(TntCountdownModule.OVERRIDE_CUSTOM_TICKS)) {
+            customTicks = currentTicks;
+
+            SetTntCountdownMessage message = SetTntCountdownMessage.newBuilder()
+                .setEntityId(NetworkTypes.toProtobuf(new ApolloEntity(primed.getEntityId(), primed.getUniqueId())))
+                .setDurationTicks(customTicks)
+                .build();
+
+            for (ApolloPlayer viewer : Apollo.getPlayerManager().getPlayers()) {
+                ((AbstractApolloPlayer) viewer).sendPacket(message);
+            }
         }
 
-        primed.setFuseTicks(customFuse);
+        primed.setFuseTicks(customTicks);
     }
 
 }

--- a/docs/developers/modules/tntcountdown.mdx
+++ b/docs/developers/modules/tntcountdown.mdx
@@ -9,7 +9,7 @@ The TNT Countdown module allows you to interact with and set custom TNT timers f
 - Adds the ability to set per TNT timers to be displayed for players using the TNT Countdown mod.
 
 <Callout type="info">
-  This module only changes the displayed TNT Countdown, you'll need to change the actual tnt-tick time server-side.
+  This module will change the actual TNT fuse time on the server, not just the countdown displayed on the client.
 </Callout>
 
 ## Integration
@@ -55,3 +55,9 @@ public void overrideTntCountdownExample(Player viewer) {
         - Type: `Integer`
         - Default: `80`
         - Minimum: `1`
+
+- __`OVERRIDE_CUSTOM_TICKS`__
+    - Whether to override custom TNT explosion ticks.
+    - Values
+        - Type: `Boolean`
+        - Default: `false`


### PR DESCRIPTION
## Overview

**Description:**
Adds a configuration option to ignore setting the custom TNT countdown ticks on TNT that has a non-default (80 ticks) duration. 

**Changes:**
If the `OVERRIDE_CUSTOM_TICKS` option is false, and the TNT fuse duration is not the default, it will send that duration for that TNTs countdown and not override it with the custom one.

**Related Issue (If applicable):**
https://github.com/LunarClient/Apollo/issues/98

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
