### PR TITLE
Fix - GitHub Release using the wrong commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,7 @@ jobs:
                 prerelease: false
                 name: "Apollo v${{ env.VERSION }}"
                 tag_name: "v${{ env.VERSION }}"
+                target_commitish: "${{ github.sha }}"
                 generate_release_notes: true
                 files: |
                     bukkit/build/libs/apollo-bukkit-${{ env.VERSION }}.jar


### PR DESCRIPTION
## Overview

**Description:**
Currently, the automated GitHub Release process utilizes the latest commit from the `master` branch, which poses an issue for us. The GitHub Actions, including the release steps, are executed on a different branch, causing discrepancies in the release process.

**Changes:**
Utilized the `github.sha` context variable to set the target commit for the release, ensuring it reflects the latest commit on the triggering branch.

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
