### PR TITLE
Chore - Add BukkitApollo#toApolloEntity utility method

### DIFF
--- a/api/src/bukkit/java/com/lunarclient/apollo/BukkitApollo.java
+++ b/api/src/bukkit/java/com/lunarclient/apollo/BukkitApollo.java
@@ -23,6 +23,7 @@
  */
 package com.lunarclient.apollo;
 
+import com.lunarclient.apollo.common.ApolloEntity;
 import com.lunarclient.apollo.common.location.ApolloBlockLocation;
 import com.lunarclient.apollo.common.location.ApolloLocation;
 import com.lunarclient.apollo.common.location.ApolloPlayerLocation;
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
 import lombok.NonNull;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 /**
@@ -133,6 +135,17 @@ public final class BukkitApollo {
             .yaw(location.getYaw())
             .pitch(location.getPitch())
             .build();
+    }
+
+    /**
+     * Converts a {@link Entity} to an {@link ApolloEntity} object.
+     *
+     * @param entity the entity
+     * @return the converted apollo entity object
+     * @since 1.1.1
+     */
+    public static ApolloEntity toApolloEntity(@NonNull Entity entity) {
+        return new ApolloEntity(entity.getEntityId(), entity.getUniqueId());
     }
 
     /**

--- a/bukkit-example/src/main/java/com/lunarclient/apollo/example/utilities/BukkitApolloExample.java
+++ b/bukkit-example/src/main/java/com/lunarclient/apollo/example/utilities/BukkitApolloExample.java
@@ -26,9 +26,11 @@ package com.lunarclient.apollo.example.utilities;
 import com.google.common.collect.Lists;
 import com.lunarclient.apollo.Apollo;
 import com.lunarclient.apollo.BukkitApollo;
+import com.lunarclient.apollo.common.ApolloEntity;
 import com.lunarclient.apollo.common.location.ApolloBlockLocation;
 import com.lunarclient.apollo.common.location.ApolloLocation;
 import com.lunarclient.apollo.module.coloredfire.ColoredFireModule;
+import com.lunarclient.apollo.module.entity.EntityModule;
 import com.lunarclient.apollo.module.hologram.Hologram;
 import com.lunarclient.apollo.module.hologram.HologramModule;
 import com.lunarclient.apollo.module.waypoint.Waypoint;
@@ -37,16 +39,20 @@ import com.lunarclient.apollo.player.ApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import java.awt.Color;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Sheep;
 
 public final class BukkitApolloExample {
 
     private final ColoredFireModule coloredFireModule = Apollo.getModuleManager().getModule(ColoredFireModule.class);
+    private final EntityModule entityModule = Apollo.getModuleManager().getModule(EntityModule.class);
     private final HologramModule hologramModule = Apollo.getModuleManager().getModule(HologramModule.class);
     private final WaypointModule waypointModule = Apollo.getModuleManager().getModule(WaypointModule.class);
 
@@ -98,6 +104,14 @@ public final class BukkitApolloExample {
             .hidden(false)
             .build()
         );
+    }
+
+    public void runEntityExample(Player player, ApolloPlayer apolloPlayer) {
+        List<ApolloEntity> sheepEntities = player.getWorld().getEntitiesByClass(Sheep.class)
+            .stream().map(BukkitApollo::toApolloEntity)
+            .collect(Collectors.toList());
+
+        this.entityModule.overrideRainbowSheep(apolloPlayer, sheepEntities);
     }
 
     private BukkitApolloExample() {

--- a/docs/developers/platform-utilities.mdx
+++ b/docs/developers/platform-utilities.mdx
@@ -84,6 +84,21 @@ public void runBlockLocationExample(ApolloPlayer apolloPlayer, Location location
     );
 }
 ```
+
+## `toApolloEntity` Method
+
+The `toApolloEntity` method is a way of converting a Bukkit `Entity` to an `ApolloEntity`.
+
+```java
+public void runEntityExample(Player player, ApolloPlayer apolloPlayer) {
+    List<ApolloEntity> sheepEntities = player.getWorld().getEntitiesByClass(Sheep.class)
+        .stream().map(BukkitApollo::toApolloEntity)
+        .collect(Collectors.toList());
+
+    this.entityModule.overrideRainbowSheep(apolloPlayer, sheepEntities);
+}
+```
+
 ## `toBukkitLocation` Method
 
 The `toBukkitLocation` method is a way of converting an `ApolloLocation`, `ApolloBlockLocation` or `ApolloPlayerLocation` back to a platform specific `Location`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.lunarclient
-version=1.1.0
+version=1.1.1-SNAPSHOT
 description=The API for interacting with Lunar Client players.
 
 org.gradle.parallel=true


### PR DESCRIPTION
## Overview

**Description:**
Added utility method for Bukkit `Entity` to `ApolloEntity` conversion.

**Changes:**
Added `BukkitApollo#toApolloEntity(org.bukkit.entity.Entity)` method

**Code Example (If applicable):**
```java
public void runEntityExample(Player player, ApolloPlayer apolloPlayer) {
      List<ApolloEntity> sheepEntities = player.getWorld().getEntitiesByClass(Sheep.class)
          .stream().map(BukkitApollo::toApolloEntity)
          .collect(Collectors.toList());

      this.entityModule.overrideRainbowSheep(apolloPlayer, sheepEntities);
  }
```

---

## Review Request Checklist

- [ ] Your code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have tested this change myself. (If applicable)
- [ ] I have made corresponding changes to the documentation. (If applicable)
- [ ] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
