### PR TITLE
Fix - Color option wrapping, unwrapping & serialization

### DIFF
--- a/common/src/main/java/com/lunarclient/apollo/option/OptionsImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/option/OptionsImpl.java
@@ -33,6 +33,7 @@ import com.lunarclient.apollo.module.ApolloModule;
 import com.lunarclient.apollo.network.NetworkOptions;
 import com.lunarclient.apollo.player.ApolloPlayer;
 import io.leangen.geantyref.GenericTypeReflector;
+import java.awt.Color;
 import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
@@ -266,12 +267,13 @@ public class OptionsImpl implements Options {
         } else if (List.class.isAssignableFrom(clazz)) {
             AnnotatedType elementType = this.elementType(boxed);
             ListValue.Builder listBuilder = ListValue.newBuilder();
-            List<?> list = (List<?>) current;
-            for (int i = 0; i < list.size(); i++) {
-                listBuilder.addValues(this.wrapValue(Value.newBuilder(), elementType.getType(), list.get(i)));
+            for (Object object : (List<?>) current) {
+                listBuilder.addValues(this.wrapValue(Value.newBuilder(), elementType.getType(), object));
             }
 
             return valueBuilder.setListValue(listBuilder.build()).build();
+        } else if (Color.class.isAssignableFrom(clazz)) {
+            return valueBuilder.setStringValue((String) current).build();
         }
 
         throw new RuntimeException("Unable to wrap value of type '" + clazz.getSimpleName() + "'!");
@@ -311,6 +313,8 @@ public class OptionsImpl implements Options {
             }
 
             return Collections.unmodifiableList(list);
+        } else if (Color.class.isAssignableFrom(clazz) && wrapper.hasStringValue()) {
+            return wrapper.getStringValue();
         }
 
         throw new RuntimeException("Unable to unwrap value of type '" + clazz.getSimpleName() + "'!");

--- a/common/src/main/java/com/lunarclient/apollo/option/config/CommonSerializers.java
+++ b/common/src/main/java/com/lunarclient/apollo/option/config/CommonSerializers.java
@@ -54,7 +54,22 @@ public final class CommonSerializers implements Serializer {
                 return null;
             }
 
-            return Color.decode(node.getString());
+            String stringValue = node.getString();
+            if (stringValue.startsWith("#")) {
+                stringValue = stringValue.substring(1);
+            }
+
+            if (stringValue.length() != 8) {
+                throw new NumberFormatException("Invalid color string length: " + stringValue);
+            }
+
+            long rgba = Long.parseLong(stringValue, 16);
+            int alpha = (int) ((rgba >> 24) & 0xFF);
+            int red = (int) ((rgba >> 16) & 0xFF);
+            int green = (int) ((rgba >> 8) & 0xFF);
+            int blue = (int) (rgba & 0xFF);
+
+            return new Color(red, green, blue, alpha);
         }
 
         @Override


### PR DESCRIPTION
## Overview

**Description:**
Improve the handling of `Color` option wrapping, unwrapping, and serialization.

**Changes:**
- Added support for wrapping the `Color` option.
- Fixed an issue with the configuration serializer to ensure proper serialization of RGBA hex values.

**Code Example:**
```java
Options options = this.modSettingModule.getOptions();
options.set(ModMemory.LOW_MEM_COLOR, "#FFFFAA00");
options.set(ModMemory.MED_MEM_COLOR, "#FFFFAA00");
options.set(ModMemory.HIGH_MEM_COLOR, "#FFFFAA00");
```

**Related Issue (If applicable):**
#155 

---

## Review Request Checklist

- [ ] Your code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have tested this change myself. (If applicable)
- [ ] I have made corresponding changes to the documentation. (If applicable)
- [ ] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
