### PR TITLE
fix: ClassCastException for Color conversion in newer Java versions

### DIFF
--- a/common/src/main/java/com/lunarclient/apollo/option/OptionsImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/option/OptionsImpl.java
@@ -273,8 +273,13 @@ public class OptionsImpl implements Options {
 
             return valueBuilder.setListValue(listBuilder.build()).build();
         } else if (Color.class.isAssignableFrom(clazz)) {
-            Color currentColor = (Color) current;
-            return valueBuilder.setStringValue(Integer.toHexString(currentColor.getRGB())).build();
+            if (current instanceof String) {
+                String string = (String) current;
+                return valueBuilder.setStringValue(string).build();
+            } else {
+                Color currentColor = (Color) current;
+                return valueBuilder.setStringValue(Integer.toHexString(currentColor.getRGB())).build();
+            }
         }
 
         throw new RuntimeException("Unable to wrap value of type '" + clazz.getSimpleName() + "'!");

--- a/common/src/main/java/com/lunarclient/apollo/option/OptionsImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/option/OptionsImpl.java
@@ -273,7 +273,8 @@ public class OptionsImpl implements Options {
 
             return valueBuilder.setListValue(listBuilder.build()).build();
         } else if (Color.class.isAssignableFrom(clazz)) {
-            return valueBuilder.setStringValue((String) current).build();
+            Color currentColor = (Color) current;
+            return valueBuilder.setStringValue(Integer.toHexString(currentColor.getRGB())).build();
         }
 
         throw new RuntimeException("Unable to wrap value of type '" + clazz.getSimpleName() + "'!");

--- a/common/src/main/java/com/lunarclient/apollo/option/OptionsImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/option/OptionsImpl.java
@@ -276,9 +276,12 @@ public class OptionsImpl implements Options {
             if (current instanceof String) {
                 String string = (String) current;
                 return valueBuilder.setStringValue(string).build();
-            } else {
+            } else if (current instanceof Color) {
                 Color currentColor = (Color) current;
                 return valueBuilder.setStringValue(Integer.toHexString(currentColor.getRGB())).build();
+            } else {
+                throw new RuntimeException("Unable to wrap Color value of type '" + clazz.getSimpleName() + "'!");
+
             }
         }
 


### PR DESCRIPTION
This commit corrects the issue by converting the `Color` object to its RGB hex string representation. The problem was that attempting to cast a `java.awt.Color` object to a `String` caused a `ClassCastException` in newer Java versions. The fix ensures that color values can be set using either HEX strings or `Color` objects without causing exceptions.

## Overview

**Description:**

This pull request resolves the issue where attempting to cast a `java.awt.Color` object to a `String` caused a `ClassCastException` in newer Java versions. The problem arose when handling color values that could be either HEX strings or `Color` objects.

**Changes:**

The code has been updated to properly handle both `String` and `Color` inputs when setting color values. Specifically:

- If the `current` value is a `String`, it is used directly.
- If the `current` value is a `Color` object, it is converted to its RGB hex string representation using `Integer.toHexString(currentColor.getRGB())` before being set.

This change ensures compatibility with both HEX string and `Color` object inputs, allowing the system to handle either type without causing exceptions.

**Code Example:**

The new implementation:

```java
if (current instanceof String) {
    String string = (String) current;
    return valueBuilder.setStringValue(string).build();
} else {
    Color currentColor = (Color) current;
    return valueBuilder.setStringValue(Integer.toHexString(currentColor.getRGB())).build();
}
```
This logic ensures that color values are consistently stored as strings, whether they originate as HEX strings or Color objects.

**Related Issue (If applicable):**
<!--- Link related issues here -->

**Screenshots and/or Videos (If applicable):**
<!--- Provide any Screenshots and/or Videos -->

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [ ] I have made corresponding changes to the documentation. (If applicable)
- [ ] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---

Thanks to @AndyReckt for his help.
