### PR TITLE
Feature - Make `ApolloPlayer` an `Audience`

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/player/ApolloPlayer.java
+++ b/api/src/main/java/com/lunarclient/apollo/player/ApolloPlayer.java
@@ -30,6 +30,7 @@ import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.world.ApolloWorld;
 import java.util.Optional;
 import java.util.UUID;
+import net.kyori.adventure.audience.ForwardingAudience;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -38,7 +39,7 @@ import org.jetbrains.annotations.ApiStatus;
  * @since 1.0.0
  */
 @ApiStatus.NonExtendable
-public interface ApolloPlayer extends Recipients {
+public interface ApolloPlayer extends Recipients, ForwardingAudience.Single {
 
     /**
      * Gets the players unique identifier.

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -19,4 +19,6 @@ dependencies {
 
     "baseAdventure4"(project(path = ":extra:apollo-extra-adventure4", configuration = "base"))
     "adventure4"(project(path = ":extra:apollo-extra-adventure4", configuration = "dependency"))
+
+    "baseAdventure4"(libs.adventure.platform.bukkit)
 }

--- a/bukkit/src/main/java/com/lunarclient/apollo/ApolloBukkitPlatform.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/ApolloBukkitPlatform.java
@@ -84,6 +84,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.messaging.Messenger;
@@ -100,12 +101,17 @@ public final class ApolloBukkitPlatform implements PlatformPlugin, ApolloPlatfor
 
     @Getter private final Options options = new OptionsImpl(null);
     @Getter private final JavaPlugin plugin;
+
+    @Getter private BukkitAudiences audiences;
     private ApolloStats stats;
 
     @Override
     public void onEnable() {
         ApolloBukkitPlatform.instance = this;
+
+        this.audiences = BukkitAudiences.create(this.plugin);
         this.stats = new BukkitApolloStats();
+
         ApolloManager.bootstrap(this);
 
         new ApolloPlayerListener(this.plugin);

--- a/bukkit/src/main/java/com/lunarclient/apollo/wrapper/BukkitApolloPlayer.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/wrapper/BukkitApolloPlayer.java
@@ -34,9 +34,11 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.audience.Audience;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The Bukkit implementation of {@link ApolloPlayer}.
@@ -88,4 +90,8 @@ public final class BukkitApolloPlayer extends AbstractApolloPlayer {
         this.player.sendPluginMessage(ApolloBukkitPlatform.getInstance().getPlugin(), ApolloManager.PLUGIN_MESSAGE_CHANNEL, messages);
     }
 
+    @Override
+    public @NotNull Audience audience() {
+        return ApolloBukkitPlatform.getInstance().getAudiences().player(this.player);
+    }
 }

--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -16,4 +16,6 @@ dependencies {
 
     "baseAdventure4"(project(path = ":extra:apollo-extra-adventure4", configuration = "base"))
     "adventure4"(project(path = ":extra:apollo-extra-adventure4", configuration = "dependency"))
+
+    "baseAdventure4"(libs.adventure.platform.bungee)
 }

--- a/bungee/src/main/java/com/lunarclient/apollo/ApolloBungeePlatform.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/ApolloBungeePlatform.java
@@ -73,6 +73,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.platform.bungeecord.BungeeAudiences;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
@@ -89,12 +90,17 @@ public final class ApolloBungeePlatform implements PlatformPlugin, ApolloPlatfor
 
     @Getter private final Options options = new OptionsImpl(null);
     @Getter private final Plugin plugin;
+
+    @Getter private BungeeAudiences audiences;
     private ApolloStats stats;
 
     @Override
     public void onEnable() {
         ApolloBungeePlatform.instance = this;
+
+        this.audiences = BungeeAudiences.create(this.plugin);
         this.stats = new BungeeApolloStats();
+
         ApolloManager.bootstrap(this);
 
         ((ApolloModuleManagerImpl) Apollo.getModuleManager())

--- a/bungee/src/main/java/com/lunarclient/apollo/wrapper/BungeeApolloPlayer.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/wrapper/BungeeApolloPlayer.java
@@ -23,13 +23,16 @@
  */
 package com.lunarclient.apollo.wrapper;
 
+import com.lunarclient.apollo.ApolloBungeePlatform;
 import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.player.ApolloPlayer;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.audience.Audience;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The Bungee implementation of {@link ApolloPlayer}.
@@ -62,4 +65,8 @@ public final class BungeeApolloPlayer extends AbstractApolloPlayer {
         this.player.sendData(ApolloManager.PLUGIN_MESSAGE_CHANNEL, messages);
     }
 
+    @Override
+    public @NotNull Audience audience() {
+        return ApolloBungeePlatform.getInstance().getAudiences().player(this.player);
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@ metadata.format.version = "1.1"
 
 [versions]
 adventure = "4.14.0"
+adventurePlatform = "4.3.3"
 artifactregistry = "2.2.1"
 bukkit = "1.8.8-R0.1-SNAPSHOT"
 bungee = "1.19-R0.1-SNAPSHOT"
@@ -22,6 +23,8 @@ lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 
 # adventure
 adventure-api = { module = "net.kyori:adventure-api", version.ref = "adventure" }
+adventure-platform-bukkit = { module = "net.kyori:adventure-platform-bukkit", version.ref = "adventurePlatform" }
+adventure-platform-bungee = { module = "net.kyori:adventure-platform-bungeecord", version.ref = "adventurePlatform" }
 adventure-textserializergson = { module = "net.kyori:adventure-text-serializer-gson", version.ref = "adventure" }
 adventure-textserializergson-legacy = { module = "net.kyori:adventure-text-serializer-gson-legacy-impl", version.ref = "adventure" }
 adventure-textserializer-legacy = { module = "net.kyori:adventure-text-serializer-legacy", version.ref = "adventure" }

--- a/velocity/src/main/java/com/lunarclient/apollo/wrapper/VelocityApolloPlayer.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/wrapper/VelocityApolloPlayer.java
@@ -30,6 +30,8 @@ import com.velocitypowered.api.proxy.Player;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.audience.Audience;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The Velocity implementation of {@link ApolloPlayer}.
@@ -62,4 +64,8 @@ public final class VelocityApolloPlayer extends AbstractApolloPlayer {
         this.player.sendPluginMessage(ApolloVelocityPlatform.PLUGIN_CHANNEL, messages);
     }
 
+    @Override
+    public @NotNull Audience audience() {
+        return this.player;
+    }
 }


### PR DESCRIPTION
## Overview

**Description:**
Makes the `ApolloPlayer` an `Audience` so it can be used with Adventure better.

**Code Example (If applicable):**
```java
Apollo.getPlayerManager().getPlayer(UUID.randomUUID())
    .ifPresent(player -> player.sendMessage(Component.text("Hello World!")));
```

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [ ] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
