### PR TITLE
Update Documentation Image Paths

### DIFF
--- a/docs/downloads.mdx
+++ b/docs/downloads.mdx
@@ -14,8 +14,8 @@ import router from "next/router";
 <DownloadList
     downloadOptions={[
         {
-            backgroundImage: "/assets/backgrounds/1.png",
-            customIcon: <img width={250} src="/assets/bukkit.png" />,
+            backgroundImage: "/backgrounds/1.png",
+            customIcon: <img width={250} src="/bukkit.png" />,
             title: "Bukkit",
             subtitle: "",
             button: [
@@ -38,8 +38,8 @@ import router from "next/router";
             },
         },
         {
-            backgroundImage: "/assets/backgrounds/2.png",
-            customIcon: <img width={250} src="/assets/bungee.png" />,
+            backgroundImage: "/backgrounds/2.png",
+            customIcon: <img width={250} src="/bungee.png" />,
             title: "Bungee",
             subtitle: "",
             button: [
@@ -62,8 +62,8 @@ import router from "next/router";
             },
         },
         {
-            backgroundImage: "/assets/backgrounds/3.png",
-            customIcon: <img width={250} src="/assets/velocity.png" />,
+            backgroundImage: "/backgrounds/3.png",
+            customIcon: <img width={250} src="/velocity.png" />,
             title: "Velocity",
             subtitle: "",
             button: [


### PR DESCRIPTION
## Overview

**Description:**
Our paths in the documentation builder were always a little odd, since we fixed them we also need to update the download page.

**Changes:**
Updates the assets to no longer be prefixed with `/asset`

**Screenshots and/or Videos (If applicable):**
<!--- Provide any Screenshots and/or Videos -->
![{AC04F60E-F9C6-4409-8EDF-BA18F9464509}](https://github.com/user-attachments/assets/997f9e22-7553-4a8c-bba7-f038a365f94a)

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
