### PR TITLE
Fix - Rich Presence Module not working on Bungee & Velocity

### DIFF
--- a/bungee/src/main/java/com/lunarclient/apollo/ApolloBungeePlatform.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/ApolloBungeePlatform.java
@@ -50,6 +50,8 @@ import com.lunarclient.apollo.module.nametag.NametagModule;
 import com.lunarclient.apollo.module.nametag.NametagModuleImpl;
 import com.lunarclient.apollo.module.notification.NotificationModule;
 import com.lunarclient.apollo.module.notification.NotificationModuleImpl;
+import com.lunarclient.apollo.module.richpresence.RichPresenceModule;
+import com.lunarclient.apollo.module.richpresence.RichPresenceModuleImpl;
 import com.lunarclient.apollo.module.serverrule.ServerRuleModule;
 import com.lunarclient.apollo.module.staffmod.StaffModModule;
 import com.lunarclient.apollo.module.staffmod.StaffModModuleImpl;
@@ -118,6 +120,7 @@ public final class ApolloBungeePlatform implements PlatformPlugin, ApolloPlatfor
             .addModule(ModSettingModule.class)
             .addModule(NametagModule.class, new NametagModuleImpl())
             .addModule(NotificationModule.class, new NotificationModuleImpl())
+            .addModule(RichPresenceModule.class, new RichPresenceModuleImpl())
             .addModule(ServerRuleModule.class)
             .addModule(StaffModModule.class, new StaffModModuleImpl())
             .addModule(StopwatchModule.class, new StopwatchModuleImpl())

--- a/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
@@ -50,6 +50,8 @@ import com.lunarclient.apollo.module.nametag.NametagModule;
 import com.lunarclient.apollo.module.nametag.NametagModuleImpl;
 import com.lunarclient.apollo.module.notification.NotificationModule;
 import com.lunarclient.apollo.module.notification.NotificationModuleImpl;
+import com.lunarclient.apollo.module.richpresence.RichPresenceModule;
+import com.lunarclient.apollo.module.richpresence.RichPresenceModuleImpl;
 import com.lunarclient.apollo.module.serverrule.ServerRuleModule;
 import com.lunarclient.apollo.module.staffmod.StaffModModule;
 import com.lunarclient.apollo.module.staffmod.StaffModModuleImpl;
@@ -175,6 +177,7 @@ public final class ApolloVelocityPlatform implements ApolloPlatform {
             .addModule(ModSettingModule.class)
             .addModule(NametagModule.class, new NametagModuleImpl())
             .addModule(NotificationModule.class, new NotificationModuleImpl())
+            .addModule(RichPresenceModule.class, new RichPresenceModuleImpl())
             .addModule(ServerRuleModule.class)
             .addModule(StaffModModule.class, new StaffModModuleImpl())
             .addModule(StopwatchModule.class, new StopwatchModuleImpl())


### PR DESCRIPTION
## Overview

**Description:**
The Rich Presence module was not being initialized on both Bungee and Velocity.

---

## Review Request Checklist

- [ ] Your code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have tested this change myself. (If applicable)
- [ ] I have made corresponding changes to the documentation. (If applicable)
- [ ] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
