### PR TITLE
Test Framework - Add Apollo payload & Border collision tests   

### DIFF
--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/ApolloApiExamplePlatform.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/ApolloApiExamplePlatform.java
@@ -25,8 +25,9 @@ package com.lunarclient.apollo.example.api;
 
 import com.lunarclient.apollo.example.ApolloExamplePlugin;
 import com.lunarclient.apollo.example.ApolloExampleType;
-import com.lunarclient.apollo.example.api.commands.debug.ApolloDebugCommand;
-import com.lunarclient.apollo.example.api.debug.SpamPacketDebug;
+import com.lunarclient.apollo.example.api.debug.DebugManager;
+import com.lunarclient.apollo.example.api.debug.command.ApolloDebugCommand;
+import com.lunarclient.apollo.example.api.debug.impl.SpamPacketDebug;
 import com.lunarclient.apollo.example.api.listener.ApolloPlayerApiListener;
 import com.lunarclient.apollo.example.api.module.AutoTextHotkeyApiExample;
 import com.lunarclient.apollo.example.api.module.BeamApiExample;
@@ -108,6 +109,7 @@ public class ApolloApiExamplePlatform extends ApolloExamplePlugin {
     public void registerListeners() {
         this.spamPacketDebug = new SpamPacketDebug();
 
+        new DebugManager();
         new ApolloPlayerApiListener(this);
     }
 

--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/Debug.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/Debug.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.example.api.debug;
+
+import com.lunarclient.apollo.example.ApolloExamplePlugin;
+import java.util.List;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+
+public abstract class Debug implements Listener {
+
+    public static final World DEBUG_WORLD = Bukkit.getWorld("world");
+
+    protected final Player player;
+
+    private List<DebugTask> steps;
+    private int phase;
+    protected boolean failed;
+
+    public Debug(Player player) {
+        this.player = player;
+        this.steps = this.steps();
+        this.phase = 1;
+
+        Bukkit.getPluginManager().registerEvents(this, ApolloExamplePlugin.getInstance());
+    }
+
+    public abstract List<DebugTask> steps();
+
+    public abstract Location startingLocation();
+
+    public abstract double allowedOffset();
+
+    public void start() {
+        this.player.teleport(this.startingLocation());
+
+        Bukkit.getScheduler().runTaskLater(
+            ApolloExamplePlugin.getInstance(),
+            () -> this.nextStepOrEnd(), 20L
+        );
+    }
+
+    public void nextStepOrEnd() {
+        if (this.steps.isEmpty()) {
+            this.end(false);
+            return;
+        }
+
+        DebugTask activeTask = this.steps.remove(0);
+        if (activeTask == null) {
+            this.end(false);
+            return;
+        }
+
+        this.player.sendMessage("Phase " + ++this.phase);
+        activeTask.run(this.player);
+
+        Bukkit.getScheduler().runTaskLater(
+            ApolloExamplePlugin.getInstance(),
+            () -> this.nextStepOrEnd(), activeTask.getDurationTicks()
+        );
+    }
+
+    public void fail() {
+        this.failed = true;
+        this.player.sendMessage(ChatColor.RED + "Failed testing at phase " + this.phase);
+    }
+
+    public void end(boolean forced) {
+        if (forced) {
+            this.player.sendMessage(ChatColor.DARK_RED + "Stopped testing...");
+        } else if (this.failed) {
+            this.player.sendMessage(ChatColor.RED + "Failed testing...");
+        } else {
+            this.player.sendMessage(ChatColor.GREEN + "Passed testing...");
+        }
+
+        HandlerList.unregisterAll(this);
+        DebugManager.getInstance().remove(this.player);
+    }
+
+}

--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/DebugManager.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/DebugManager.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.example.api.debug;
+
+import com.lunarclient.apollo.example.ApolloExamplePlugin;
+import com.lunarclient.apollo.example.api.debug.payload.PayloadListener;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Getter;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+
+public class DebugManager implements Listener {
+
+    @Getter
+    private static DebugManager instance;
+
+    private final Map<UUID, Debug> players;
+
+    public DebugManager() {
+        instance = this;
+
+        this.players = new HashMap<>();
+
+        new PayloadListener();
+
+        Bukkit.getPluginManager().registerEvents(this, ApolloExamplePlugin.getInstance());
+    }
+
+    public void remove(Player player) {
+        this.players.remove(player.getUniqueId());
+    }
+
+    public void start(Player player, Debug debug) {
+        if (this.players.containsKey(player.getUniqueId())) {
+            player.sendMessage("Already debugging!");
+            return;
+        }
+
+        this.players.put(player.getUniqueId(), debug);
+        debug.start();
+
+        player.sendMessage("Starting debug!");
+    }
+
+    public void stop(Player player) {
+        Debug debug = this.players.remove(player.getUniqueId());
+
+        if (debug == null) {
+            player.sendMessage("Not debugging!");
+            return;
+        }
+
+        debug.end(true);
+    }
+
+}

--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/DebugTask.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/DebugTask.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.example.api.debug;
+
+import com.lunarclient.apollo.Apollo;
+import com.lunarclient.apollo.player.ApolloPlayer;
+import java.util.function.BiConsumer;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.entity.Player;
+
+@Getter
+@RequiredArgsConstructor
+public class DebugTask {
+
+    private final int durationTicks;
+    private final BiConsumer<Player, ApolloPlayer> action;
+    private final String message;
+
+    public void run(Player player) {
+        Apollo.getPlayerManager().getPlayer(player.getUniqueId())
+            .ifPresent(apolloPlayer -> {
+                player.sendMessage(this.message);
+                this.action.accept(player, apolloPlayer);
+            });
+    }
+
+}

--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/command/ApolloDebugCommand.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/command/ApolloDebugCommand.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.lunarclient.apollo.example.api.commands.debug;
+package com.lunarclient.apollo.example.api.debug.command;
 
 import com.lunarclient.apollo.common.ApolloComponent;
 import net.kyori.adventure.text.Component;
@@ -51,13 +51,19 @@ public class ApolloDebugCommand implements CommandExecutor {
                 .append(Component.text("/apollodebug spampackets [start|stop|stopall] ", NamedTextColor.WHITE))
                 .append(Component.text("# Spam modsetting update packets to the client.", NamedTextColor.GREEN))
                 .appendNewline()
+                .append(Component.text("/apollodebug borders [start|stop] ", NamedTextColor.WHITE))
+                .append(Component.text("# Border collision test.", NamedTextColor.GREEN))
+                .appendNewline()
                 .append(Component.text("-------------------------------------", NamedTextColor.GRAY, TextDecoration.STRIKETHROUGH))
                 .build()
             ));
         } else if(args[0].equalsIgnoreCase("spampackets")) {
             return new SpamPacketsCommand().onCommand(sender, command, label, args);
+        } else if (args[0].equalsIgnoreCase("borders")) {
+            return new BordersCommand().onCommand(sender, command, label, args);
         }
 
         return true;
     }
+
 }

--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/command/BordersCommand.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/command/BordersCommand.java
@@ -21,11 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.lunarclient.apollo.example.api.commands.debug;
+package com.lunarclient.apollo.example.api.debug.command;
 
 import com.lunarclient.apollo.common.ApolloComponent;
-import com.lunarclient.apollo.example.api.ApolloApiExamplePlatform;
-import com.lunarclient.apollo.example.api.debug.SpamPacketDebug;
+import com.lunarclient.apollo.example.api.debug.DebugManager;
+import com.lunarclient.apollo.example.api.debug.impl.BorderCollisionTest;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -35,9 +35,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-public class SpamPacketsCommand implements CommandExecutor {
-
-    private final SpamPacketDebug spamPacketDebug = ApolloApiExamplePlatform.getInstance().getSpamPacketDebug();
+public class BordersCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
@@ -47,37 +45,27 @@ public class SpamPacketsCommand implements CommandExecutor {
         }
 
         Player player = (Player) sender;
+        DebugManager debugManager = DebugManager.getInstance();
 
         if (args.length < 2) {
             this.sendUsage(player);
-        } else {
-            switch (args[1].toLowerCase()) {
-                case "start": {
-                    int amount = args.length > 2 ? Integer.parseInt(args[2]) : Integer.MAX_VALUE;
-                    int delay = args.length > 3 ? Integer.parseInt(args[3]) : 50;
+            return true;
+        }
 
-                    this.spamPacketDebug.start(player, amount, delay, () -> player.sendMessage("Debug completed!"));
+        switch (args[1].toLowerCase()) {
+            case "start": {
+                debugManager.start(player, new BorderCollisionTest(player));
+                break;
+            }
 
-                    player.sendMessage("Debug started. (Amount: " + amount + ", Delay: " + delay + "ms)");
-                    break;
-                }
+            case "stop": {
+                debugManager.stop(player);
+                break;
+            }
 
-                case "stop": {
-                    this.spamPacketDebug.stop(player);
-                    player.sendMessage("Debug stopped.");
-                    break;
-                }
-
-                case "stopall": {
-                    this.spamPacketDebug.stopAll();
-                    player.sendMessage("Debug stopped for all debuggers.");
-                    break;
-                }
-
-                default: {
-                    this.sendUsage(player);
-                    break;
-                }
+            default: {
+                this.sendUsage(player);
+                break;
             }
         }
 
@@ -88,17 +76,15 @@ public class SpamPacketsCommand implements CommandExecutor {
         player.sendMessage(ApolloComponent.toLegacy(Component.text()
             .append(Component.text("-------------------------------------", NamedTextColor.GRAY, TextDecoration.STRIKETHROUGH))
             .appendNewline()
-            .append(Component.text("/apollodebug spampackets start <amount> <delay> ", NamedTextColor.WHITE))
-            .append(Component.text("# Starts spamming modsetting update packets to the client, delay is in milliseconds.", NamedTextColor.GREEN))
+            .append(Component.text("/apollodebug borders start", NamedTextColor.WHITE))
+            .append(Component.text("# Starts the borders collision test, bouncing you towards the border walls", NamedTextColor.GREEN))
             .appendNewline()
-            .append(Component.text("/apollodebug spampackets stop ", NamedTextColor.WHITE))
-            .append(Component.text("# Stop spamming modsetting update packets to the client.", NamedTextColor.GREEN))
-            .appendNewline()
-            .append(Component.text("/apollodebug spampackets stopall ", NamedTextColor.WHITE))
-            .append(Component.text("# Stops spamming modsetting update packets to the client, for all debuggers.", NamedTextColor.GREEN))
+            .append(Component.text("/apollodebug borders stop ", NamedTextColor.WHITE))
+            .append(Component.text("# Stop the borders collision test.", NamedTextColor.GREEN))
             .appendNewline()
             .append(Component.text("-------------------------------------", NamedTextColor.GRAY, TextDecoration.STRIKETHROUGH))
             .build()
         ));
     }
+
 }

--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/command/SpamPacketsCommand.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/command/SpamPacketsCommand.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.example.api.debug.command;
+
+import com.lunarclient.apollo.common.ApolloComponent;
+import com.lunarclient.apollo.example.api.ApolloApiExamplePlatform;
+import com.lunarclient.apollo.example.api.debug.impl.SpamPacketDebug;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class SpamPacketsCommand implements CommandExecutor {
+
+    private final SpamPacketDebug spamPacketDebug = ApolloApiExamplePlatform.getInstance().getSpamPacketDebug();
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Player only!");
+            return true;
+        }
+
+        Player player = (Player) sender;
+
+        if (args.length < 2) {
+            this.sendUsage(player);
+        } else {
+            switch (args[1].toLowerCase()) {
+                case "start": {
+                    int amount = args.length > 2 ? Integer.parseInt(args[2]) : Integer.MAX_VALUE;
+                    int delay = args.length > 3 ? Integer.parseInt(args[3]) : 50;
+
+                    this.spamPacketDebug.start(player, amount, delay, () -> player.sendMessage("Debug completed!"));
+
+                    player.sendMessage("Debug started. (Amount: " + amount + ", Delay: " + delay + "ms)");
+                    break;
+                }
+
+                case "stop": {
+                    this.spamPacketDebug.stop(player);
+                    player.sendMessage("Debug stopped.");
+                    break;
+                }
+
+                case "stopall": {
+                    this.spamPacketDebug.stopAll();
+                    player.sendMessage("Debug stopped for all debuggers.");
+                    break;
+                }
+
+                default: {
+                    this.sendUsage(player);
+                    break;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private void sendUsage(Player player) {
+        player.sendMessage(ApolloComponent.toLegacy(Component.text()
+            .append(Component.text("-------------------------------------", NamedTextColor.GRAY, TextDecoration.STRIKETHROUGH))
+            .appendNewline()
+            .append(Component.text("/apollodebug spampackets start <amount> <delay> ", NamedTextColor.WHITE))
+            .append(Component.text("# Starts spamming modsetting update packets to the client, delay is in milliseconds.", NamedTextColor.GREEN))
+            .appendNewline()
+            .append(Component.text("/apollodebug spampackets stop ", NamedTextColor.WHITE))
+            .append(Component.text("# Stop spamming modsetting update packets to the client.", NamedTextColor.GREEN))
+            .appendNewline()
+            .append(Component.text("/apollodebug spampackets stopall ", NamedTextColor.WHITE))
+            .append(Component.text("# Stops spamming modsetting update packets to the client, for all debuggers.", NamedTextColor.GREEN))
+            .appendNewline()
+            .append(Component.text("-------------------------------------", NamedTextColor.GRAY, TextDecoration.STRIKETHROUGH))
+            .build()
+        ));
+    }
+
+}

--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/impl/BorderCollisionTest.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/impl/BorderCollisionTest.java
@@ -1,0 +1,201 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.example.api.debug.impl;
+
+import com.lunarclient.apollo.Apollo;
+import com.lunarclient.apollo.common.cuboid.Cuboid2D;
+import com.lunarclient.apollo.example.ApolloExamplePlugin;
+import com.lunarclient.apollo.example.api.debug.Debug;
+import com.lunarclient.apollo.example.api.debug.DebugTask;
+import com.lunarclient.apollo.module.border.Border;
+import com.lunarclient.apollo.module.border.BorderModule;
+import java.awt.Color;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.NumberConversions;
+import org.bukkit.util.Vector;
+
+public class BorderCollisionTest extends Debug {
+
+    private final BorderModule borderModule = Apollo.getModuleManager().getModule(BorderModule.class);
+    private final Cuboid2D border = Cuboid2D.builder()
+        .minX(200).minZ(200)
+        .maxX(200).maxZ(200)
+        .build();
+
+    public BorderCollisionTest(Player player) {
+        super(player);
+    }
+
+    @Override
+    public Location startingLocation() {
+        return new Location(DEBUG_WORLD, 200.5D, 100D, 200.5D);
+    }
+
+    @Override
+    public double allowedOffset() {
+        return 1.0D;
+    }
+
+    @Override
+    public List<DebugTask> steps() {
+        List<DebugTask> tasks = new LinkedList<>();
+
+        tasks.add(new DebugTask(1, (player, apolloPlayer) -> {
+            this.borderModule.displayBorder(apolloPlayer, this.createBorder()
+                .id("border-debug")
+                .bounds(this.border)
+                .build());
+        }, "Displaying 1x1 Border"));
+
+        tasks.add(new DebugTask(60, (player, apolloPlayer) -> {
+            new BounceTask(10, 3);
+        }, "Boucning Player"));
+
+        tasks.add(new DebugTask(10, (player, apolloPlayer) -> {
+            this.borderModule.removeBorder(apolloPlayer, "border-debug");
+        }, "Clear Border"));
+
+        tasks.add(new DebugTask(10, (player, apolloPlayer) -> {
+            player.teleport(this.startingLocation());
+        }, "Teleporting to starting location"));
+
+        tasks.add(new DebugTask(1, (player, apolloPlayer) -> {
+            this.borderModule.displayBorder(apolloPlayer, this.createBorder()
+                .id("border-debug-north")
+                .bounds(Cuboid2D.builder()
+                    .minX(200).maxX(200)
+                    .minZ(199).maxZ(199)
+                    .build())
+                .build());
+
+            this.borderModule.displayBorder(apolloPlayer, this.createBorder()
+                .id("border-debug-east")
+                .bounds(Cuboid2D.builder()
+                    .minX(201).maxX(201)
+                    .minZ(200).maxZ(200)
+                    .build())
+                .build());
+
+            this.borderModule.displayBorder(apolloPlayer, this.createBorder()
+                .id("border-debug-south")
+                .bounds(Cuboid2D.builder()
+                    .minX(200).maxX(200)
+                    .minZ(201).maxZ(201)
+                    .build())
+                .build());
+
+            this.borderModule.displayBorder(apolloPlayer, this.createBorder()
+                .id("border-debug-west")
+                .bounds(Cuboid2D.builder()
+                    .minX(199).maxX(199)
+                    .minZ(200).maxZ(200)
+                    .build())
+                .build());
+        }, "Displaying 4 1x1 Borders"));
+
+        tasks.add(new DebugTask(60, (player, apolloPlayer) -> {
+            new BounceTask(10, 3);
+        }, "Boucning Player"));
+
+        tasks.add(new DebugTask(10, (player, apolloPlayer) -> {
+            this.borderModule.removeBorder(apolloPlayer, "border-debug-north");
+            this.borderModule.removeBorder(apolloPlayer, "border-debug-east");
+            this.borderModule.removeBorder(apolloPlayer, "border-debug-south");
+            this.borderModule.removeBorder(apolloPlayer, "border-debug-west");
+        }, "Clear Borders"));
+
+        return tasks;
+    }
+
+    private Border.BorderBuilder createBorder() {
+        return Border.builder()
+            .world(DEBUG_WORLD.getName())
+            .cancelEntry(true)
+            .cancelExit(true)
+            .canShrinkOrExpand(false)
+            .color(Color.RED)
+            .durationTicks(1000);
+    }
+
+    private void bouncePlayer(Player player) {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        double x = (random.nextDouble() - 0.5) * 2;
+        double y = random.nextDouble() * 1.2 + 0.1;
+        double z = (random.nextDouble() - 0.5) * 2;
+
+        Vector velocity = new Vector(x, y, z);
+        player.setVelocity(velocity);
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    private void onPlayerMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        if (player != this.player || this.failed) {
+            return;
+        }
+
+        Location location = player.getLocation();
+
+        Location startingLocation = this.startingLocation();
+        double distance = Math.sqrt(NumberConversions.square(location.getX() - startingLocation.getX())
+            + NumberConversions.square(location.getZ() - startingLocation.getZ()));
+
+        if (distance > this.allowedOffset()) {
+            this.fail();
+        }
+    }
+
+    private class BounceTask extends BukkitRunnable {
+
+        private final int amount;
+
+        private int bounces;
+
+        BounceTask(int amount, int ticks) {
+            this.amount = amount;
+
+            this.runTaskTimer(
+                ApolloExamplePlugin.getInstance(),
+                ticks, ticks
+            );
+        }
+
+        @Override
+        public void run() {
+            BorderCollisionTest.this.bouncePlayer(player);
+
+            if (++this.bounces == this.amount) {
+                this.cancel();
+            }
+        }
+    }
+}

--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/impl/SpamPacketDebug.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/impl/SpamPacketDebug.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.lunarclient.apollo.example.api.debug;
+package com.lunarclient.apollo.example.api.debug.impl;
 
 import com.google.common.collect.Maps;
 import com.lunarclient.apollo.Apollo;

--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/payload/PayloadListener.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/debug/payload/PayloadListener.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.example.api.debug.payload;
+
+import com.lunarclient.apollo.Apollo;
+import com.lunarclient.apollo.event.ApolloListener;
+import com.lunarclient.apollo.event.EventBus;
+import com.lunarclient.apollo.event.Listen;
+import com.lunarclient.apollo.event.player.ApolloPlayerHandshakeEvent;
+import com.lunarclient.apollo.example.ApolloExamplePlugin;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class PayloadListener implements Listener, ApolloListener {
+
+    private final Set<UUID> handshakeUuids;
+
+    public PayloadListener() {
+        this.handshakeUuids = new HashSet<>();
+
+        EventBus.getBus().register(this);
+        Bukkit.getPluginManager().registerEvents(this, ApolloExamplePlugin.getInstance());
+    }
+
+    private void checkReceivedPackets(Player player) {
+        Bukkit.getScheduler().runTaskLater(ApolloExamplePlugin.getInstance(), () -> {
+            UUID uuid = player.getUniqueId();
+
+            boolean register = Apollo.getPlayerManager().hasSupport(uuid);
+            boolean handshake = this.handshakeUuids.contains(uuid);
+
+            if (register && !handshake) {
+                player.sendMessage(ChatColor.RED + "Received Apollo register but not the handshake!");
+            } else if (!register && !handshake) {
+                player.sendMessage(ChatColor.RED + "Failed to receive Apollo register and handshake!");
+            }
+        }, 20 * 3);
+    }
+
+    @EventHandler
+    private void onPlayerJoin(PlayerJoinEvent event) {
+        this.checkReceivedPackets(event.getPlayer());
+    }
+
+    @EventHandler
+    private void onPlayerQuit(PlayerQuitEvent event) {
+        this.handshakeUuids.remove(event.getPlayer().getUniqueId());
+    }
+
+    @Listen
+    private void onApolloPlayerHandshake(ApolloPlayerHandshakeEvent event) {
+        this.handshakeUuids.add(event.getPlayer().getUniqueId());
+    }
+
+}

--- a/bukkit-example-common/src/main/java/com/lunarclient/apollo/example/module/NMSExample.java
+++ b/bukkit-example-common/src/main/java/com/lunarclient/apollo/example/module/NMSExample.java
@@ -28,10 +28,14 @@ import org.bukkit.Bukkit;
 public class NMSExample extends ApolloModuleExample {
 
     public boolean isOneEight() {
-        return Bukkit.getServer().getClass()
-            .getPackage().getName()
-            .split("\\.")[3]
-            .startsWith("v1_8");
+        try {
+            return Bukkit.getServer().getClass()
+                .getPackage().getName()
+                .split("\\.")[3]
+                .startsWith("v1_8");
+        } catch (IndexOutOfBoundsException e) {
+            return false;
+        }
     }
 
 }


### PR DESCRIPTION
## Overview

**Description:**
Introduce a functional test to verify border collisions for the `Border Module`

**Changes:**
Implemented `BorderCollisionTest`, which fails if the player moves outside the expected bounds:
 - Displays a single 1x1 border.
 - Applies randomized velocity to push the player against the border walls.
 - Clears the border and resets the player's position.
 - Displays four 1x1 borders (north, south, east, west) surrounding the player.
 - Applies randomized velocity again
- Added a `/apollodebug borders [start|stop]` command to run the test.


**Screenshots and/or Videos:**

https://github.com/user-attachments/assets/4c684f25-a9bd-4d62-b890-752ebfb5865f

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
