### PR TITLE
Glow Module - Add Scoreborard Team Color Fallback

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/module/glow/GlowModule.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/glow/GlowModule.java
@@ -47,6 +47,20 @@ public abstract class GlowModule extends ApolloModule {
     /**
      * Overrides the glow effect for the glowingPlayer, visible by the viewers.
      *
+     * <p>If no color is specified, the glowing color will match the player's scoreboard team color.</p>
+     *
+     *
+     * @param recipients    the recipients that are receiving the packet
+     * @param glowingPlayer the UUID of the player whose glowing effect will be overwrote
+     * @since 1.1.9
+     */
+    public abstract void overrideGlow(Recipients recipients, UUID glowingPlayer);
+
+    /**
+     * Overrides the glow effect for the glowingPlayer, visible by the viewers.
+     *
+     * <p>If the {@code color} parameter is {@code null}, the glowing color will match the player's scoreboard team color.</p>
+     *
      * @param recipients    the recipients that are receiving the packet
      * @param glowingPlayer the UUID of the player whose glowing effect will be overwrote
      * @param color         the new color glowingPlayer should glow in.

--- a/common/src/main/java/com/lunarclient/apollo/module/glow/GlowModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/glow/GlowModuleImpl.java
@@ -32,6 +32,7 @@ import com.lunarclient.apollo.recipients.Recipients;
 import java.awt.Color;
 import java.util.UUID;
 import lombok.NonNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Provides the glow module.
@@ -41,12 +42,20 @@ import lombok.NonNull;
 public final class GlowModuleImpl extends GlowModule {
 
     @Override
-    public void overrideGlow(@NonNull Recipients recipients, @NonNull UUID glowingPlayer, @NonNull Color color) {
-        OverrideGlowEffectMessage message = OverrideGlowEffectMessage.newBuilder()
-            .setPlayerUuid(NetworkTypes.toProtobuf(glowingPlayer))
-            .setColor(NetworkTypes.toProtobuf(color))
-            .build();
+    public void overrideGlow(@NonNull Recipients recipients, @NonNull UUID glowingPlayer) {
+        this.overrideGlow(recipients, glowingPlayer, null);
+    }
 
+    @Override
+    public void overrideGlow(@NonNull Recipients recipients, @NonNull UUID glowingPlayer, @Nullable Color color) {
+        OverrideGlowEffectMessage.Builder builder = OverrideGlowEffectMessage.newBuilder()
+            .setPlayerUuid(NetworkTypes.toProtobuf(glowingPlayer));
+
+        if (color != null) {
+            builder.setColor(NetworkTypes.toProtobuf(color));
+        }
+
+        OverrideGlowEffectMessage message = builder.build();
         recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
     }
 

--- a/docs/developers/modules/glow.mdx
+++ b/docs/developers/modules/glow.mdx
@@ -10,7 +10,6 @@ The glow module allows you to take advantage of the vanilla Minecraft Glow Effec
 -   Backports all vanilla Minecraft glow effect functionality, found on 1.9+ to the 1.7 and 1.8 version of Lunar Client.
 -   Adds improvements to glow effect for Lunar Client users.
     -   Customizable colors for the glow effect, different from the vanilla Minecraft colors.
-    -   If no color is specified, the glow effect will default to the player's scoreboard team color.
 
 <Callout type="Warning">
   In Version 1.12, Optifine's 'Fast Render' setting alters player rendering. This is expected behavior for Optifine.
@@ -23,6 +22,10 @@ The glow module allows you to take advantage of the vanilla Minecraft Glow Effec
 </div>
 
 ## Integration
+
+<Callout type="info">
+  If no color is specified, the glow effect will default to the player's scoreboard team color.
+</Callout>
 
 ### Sample Code
 Explore each integration by cycling through each tab, to find the best fit for your requirements and needs.

--- a/docs/developers/modules/glow.mdx
+++ b/docs/developers/modules/glow.mdx
@@ -10,6 +10,7 @@ The glow module allows you to take advantage of the vanilla Minecraft Glow Effec
 -   Backports all vanilla Minecraft glow effect functionality, found on 1.9+ to the 1.7 and 1.8 version of Lunar Client.
 -   Adds improvements to glow effect for Lunar Client users.
     -   Customizable colors for the glow effect, different from the vanilla Minecraft colors.
+    -   If no color is specified, the glow effect will default to the player's scoreboard team color.
 
 <Callout type="Warning">
   In Version 1.12, Optifine's 'Fast Render' setting alters player rendering. This is expected behavior for Optifine.
@@ -65,6 +66,7 @@ public void resetGlowEffectsExample(Player viewer) {
 2. `UUID target`
    - The player or living entity you want to display the glow effect on.
 3. `Color glowColor`
+   - If `null` is passed (or if no color is specified), the glow effect will default to the target's scoreboard team color.
    - How you'll dictate the color of the glow effect, see the [colors page](/apollo/developers/utilities/colors) for more.
 
 </Tab>


### PR DESCRIPTION
## Overview

**Description:**
Introduce a new **Glow Module** API method that allows overriding the glow effect for a player without explicitly specifying a color. When no color is provided, the glow effect will fall back to the player's scoreboard team color.

**Changes:**
- Added `GlowModule#overrideGlow(Recipients, UUID)` method, supporting scoreboard team color fallback.
- Updated internal implementation to handle `null` color values.
- Updated documentation to reflect fallback behavior.

**Code Example:**
```java
public void overrideGlowEffectExample(UUID glowingPlayer) {
    this.glowModule.overrideGlow(Recipients.ofEveryone(), glowingPlayer);
}
```

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
