### PR TITLE
Improvement - Include the packet sender in Packet Enrichment Events

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/event/packetenrichment/chat/ApolloPlayerChatCloseEvent.java
+++ b/api/src/main/java/com/lunarclient/apollo/event/packetenrichment/chat/ApolloPlayerChatCloseEvent.java
@@ -25,6 +25,7 @@ package com.lunarclient.apollo.event.packetenrichment.chat;
 
 import com.lunarclient.apollo.event.Event;
 import com.lunarclient.apollo.module.packetenrichment.PlayerInfo;
+import com.lunarclient.apollo.player.ApolloPlayer;
 import lombok.Value;
 
 /**
@@ -34,6 +35,14 @@ import lombok.Value;
  */
 @Value
 public class ApolloPlayerChatCloseEvent implements Event {
+
+    /**
+     * The player that sent the packet.
+     *
+     * @return the player
+     * @since 1.1.9
+     */
+    ApolloPlayer player;
 
     /**
      * The {@code long} representing the unix timestamp

--- a/api/src/main/java/com/lunarclient/apollo/event/packetenrichment/chat/ApolloPlayerChatOpenEvent.java
+++ b/api/src/main/java/com/lunarclient/apollo/event/packetenrichment/chat/ApolloPlayerChatOpenEvent.java
@@ -25,6 +25,7 @@ package com.lunarclient.apollo.event.packetenrichment.chat;
 
 import com.lunarclient.apollo.event.Event;
 import com.lunarclient.apollo.module.packetenrichment.PlayerInfo;
+import com.lunarclient.apollo.player.ApolloPlayer;
 import lombok.Value;
 
 /**
@@ -34,6 +35,14 @@ import lombok.Value;
  */
 @Value
 public class ApolloPlayerChatOpenEvent implements Event {
+
+    /**
+     * The player that sent the packet.
+     *
+     * @return the player
+     * @since 1.1.9
+     */
+    ApolloPlayer player;
 
     /**
      * The {@code long} representing the unix timestamp

--- a/api/src/main/java/com/lunarclient/apollo/event/packetenrichment/melee/ApolloPlayerAttackEvent.java
+++ b/api/src/main/java/com/lunarclient/apollo/event/packetenrichment/melee/ApolloPlayerAttackEvent.java
@@ -25,6 +25,7 @@ package com.lunarclient.apollo.event.packetenrichment.melee;
 
 import com.lunarclient.apollo.event.Event;
 import com.lunarclient.apollo.module.packetenrichment.PlayerInfo;
+import com.lunarclient.apollo.player.ApolloPlayer;
 import lombok.Value;
 
 /**
@@ -34,6 +35,14 @@ import lombok.Value;
  */
 @Value
 public class ApolloPlayerAttackEvent implements Event {
+
+    /**
+     * The player that sent the packet.
+     *
+     * @return the player
+     * @since 1.1.9
+     */
+    ApolloPlayer player;
 
     /**
      * The {@code long} representing the unix timestamp

--- a/api/src/main/java/com/lunarclient/apollo/event/packetenrichment/world/ApolloPlayerUseItemEvent.java
+++ b/api/src/main/java/com/lunarclient/apollo/event/packetenrichment/world/ApolloPlayerUseItemEvent.java
@@ -25,6 +25,7 @@ package com.lunarclient.apollo.event.packetenrichment.world;
 
 import com.lunarclient.apollo.event.Event;
 import com.lunarclient.apollo.module.packetenrichment.PlayerInfo;
+import com.lunarclient.apollo.player.ApolloPlayer;
 import lombok.Value;
 
 /**
@@ -34,6 +35,14 @@ import lombok.Value;
  */
 @Value
 public class ApolloPlayerUseItemEvent implements Event {
+
+    /**
+     * The player that sent the packet.
+     *
+     * @return the player
+     * @since 1.1.9
+     */
+    ApolloPlayer player;
 
     /**
      * The {@code long} representing the unix timestamp

--- a/common/src/main/java/com/lunarclient/apollo/module/packetenrichment/PacketEnrichmentImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/packetenrichment/PacketEnrichmentImpl.java
@@ -55,6 +55,7 @@ public final class PacketEnrichmentImpl extends PacketEnrichmentModule {
     private void onReceivePacket(ApolloReceivePacketEvent event) {
         event.unpack(PlayerAttackMessage.class).ifPresent(packet -> {
             ApolloPlayerAttackEvent playerAttackEvent = new ApolloPlayerAttackEvent(
+                event.getPlayer(),
                 NetworkTypes.fromProtobuf(packet.getPacketInfo().getInstantiationTime()),
                 NetworkTypes.fromProtobuf(packet.getTargetInfo()),
                 NetworkTypes.fromProtobuf(packet.getAttackerInfo()),
@@ -70,6 +71,7 @@ public final class PacketEnrichmentImpl extends PacketEnrichmentModule {
 
         event.unpack(PlayerChatOpenMessage.class).ifPresent(packet -> {
             ApolloPlayerChatOpenEvent playerChatOpenEvent = new ApolloPlayerChatOpenEvent(
+                event.getPlayer(),
                 NetworkTypes.fromProtobuf(packet.getPacketInfo().getInstantiationTime()),
                 NetworkTypes.fromProtobuf(packet.getPlayerInfo()));
 
@@ -82,6 +84,7 @@ public final class PacketEnrichmentImpl extends PacketEnrichmentModule {
 
         event.unpack(PlayerChatCloseMessage.class).ifPresent(packet -> {
             ApolloPlayerChatCloseEvent playerChatCloseEvent = new ApolloPlayerChatCloseEvent(
+                event.getPlayer(),
                 NetworkTypes.fromProtobuf(packet.getPacketInfo().getInstantiationTime()),
                 NetworkTypes.fromProtobuf(packet.getPlayerInfo()));
 
@@ -94,6 +97,7 @@ public final class PacketEnrichmentImpl extends PacketEnrichmentModule {
 
         event.unpack(PlayerUseItemMessage.class).ifPresent(packet -> {
             ApolloPlayerUseItemEvent playerUseItemEvent = new ApolloPlayerUseItemEvent(
+                event.getPlayer(),
                 NetworkTypes.fromProtobuf(packet.getPacketInfo().getInstantiationTime()),
                 NetworkTypes.fromProtobuf(packet.getPlayerInfo()),
                 packet.getMainHand()

--- a/docs/developers/events.mdx
+++ b/docs/developers/events.mdx
@@ -183,6 +183,7 @@ _Called when the player closes their chat._
 
 | Field                      | Description                                        |
 | -------------------------- | -------------------------------------------------- |
+| `ApolloPlayer player`      | The Apollo player that sent the packet.            |
 | `long instantiationTimeMs` | The unix timestamp when the packet was created.    |
 | `PlayerInfo playerInfo`    | The player's general information.                  |
 
@@ -197,6 +198,7 @@ _Called when the player opens their chat._
 
 | Field                      | Description                                        |
 | -------------------------- | -------------------------------------------------- |
+| `ApolloPlayer player`      | The Apollo player that sent the packet.            |
 | `long instantiationTimeMs` | The unix timestamp when the packet was created.    |
 | `PlayerInfo playerInfo`    | The player's general information.                  |
 
@@ -211,6 +213,7 @@ _Called when the player attacks another player._
 
 | Field                      | Description                                        |
 | -------------------------- | -------------------------------------------------- |
+| `ApolloPlayer player`      | The Apollo player that sent the packet.            |
 | `long instantiationTimeMs` | The unix timestamp when the packet was created.    |
 | `PlayerInfo targetInfo`    | The target player general information.             |
 | `PlayerInfo attackerInfo`  | The attacker player general information.           |
@@ -227,6 +230,7 @@ _Called when the player uses an item (1.16.1+)._
 
 | Field                      | Description                                        |
 | -------------------------- | -------------------------------------------------- |
+| `ApolloPlayer player`      | The Apollo player that sent the packet.            |
 | `long instantiationTimeMs` | The unix timestamp when the packet was created.    |
 | `PlayerInfo playerInfo`    | The player's general information.                  |
 | `boolean mainHand`         | Whether the item was in the player's main hand.    |


### PR DESCRIPTION
## Overview

**Description:**
Add the packet sender (`ApolloPlayer`) to all Packet Enrichment Module Events.

**Changes:**
Added `player` field to:
- `ApolloPlayerChatCloseEvent`
- `ApolloPlayerChatOpenEvent`
- `ApolloPlayerAttackEvent`
- `ApolloPlayerUseItemEvent`

**Code Example**
```java
@Listen
private void onApolloPlayerChatClose(ApolloPlayerChatCloseEvent event) {
    ApolloPlayer sender = event.getPlayer();
}
```

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
