### PR TITLE
Title Module - Add a option to clear the title on server switch

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/module/title/TitleModule.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/title/TitleModule.java
@@ -25,7 +25,10 @@ package com.lunarclient.apollo.module.title;
 
 import com.lunarclient.apollo.module.ApolloModule;
 import com.lunarclient.apollo.module.ModuleDefinition;
+import com.lunarclient.apollo.option.Option;
+import com.lunarclient.apollo.option.SimpleOption;
 import com.lunarclient.apollo.recipients.Recipients;
+import io.leangen.geantyref.TypeToken;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -39,6 +42,27 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.NonExtendable
 @ModuleDefinition(id = "title", name = "Title")
 public abstract class TitleModule extends ApolloModule {
+
+    /**
+     * Determines whether the players displayed title should clear when switching servers.
+     *
+     * @since 1.1.9
+     */
+    public static final SimpleOption<Boolean> CLEAR_TITLE_ON_SERVER_SWITCH = Option.<Boolean>builder()
+        .comment("Set to 'true' to clear the shown title when changing servers, otherwise 'false'.")
+        .node("clear-title-on-server-switch").type(TypeToken.get(Boolean.class))
+        .defaultValue(false).notifyClient().build();
+
+    TitleModule() {
+        this.registerOptions(
+            TitleModule.CLEAR_TITLE_ON_SERVER_SWITCH
+        );
+    }
+
+    @Override
+    public boolean isClientNotify() {
+        return true;
+    }
 
     /**
      * Sends the {@link Title} to the {@link Recipients}.

--- a/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/module/TitleApiExample.java
+++ b/bukkit-example-api/src/main/java/com/lunarclient/apollo/example/api/module/TitleApiExample.java
@@ -82,4 +82,9 @@ public class TitleApiExample extends TitleExample {
         apolloPlayerOpt.ifPresent(this.titleModule::resetTitles);
     }
 
+    @Override
+    public void setClearTitleOnServerSwitch(boolean value) {
+        this.titleModule.getOptions().set(TitleModule.CLEAR_TITLE_ON_SERVER_SWITCH, value);
+    }
+
 }

--- a/bukkit-example-common/src/main/java/com/lunarclient/apollo/example/command/TitleCommand.java
+++ b/bukkit-example-common/src/main/java/com/lunarclient/apollo/example/command/TitleCommand.java
@@ -41,13 +41,21 @@ public class TitleCommand implements CommandExecutor {
         }
 
         Player player = (Player) sender;
+        TitleExample titleExample = ApolloExamplePlugin.getInstance().getTitleExample();
 
-        if (args.length != 1) {
-            player.sendMessage("Usage: /title <display|displayInterpolated|reset>");
+        if (args.length == 2 && args[0].equalsIgnoreCase("clearOnServerSwitch")) {
+            boolean value = Boolean.parseBoolean(args[1]);
+            titleExample.setClearTitleOnServerSwitch(value);
+
+            player.sendMessage("Clear title on server switch has been set to " + value);
             return true;
         }
 
-        TitleExample titleExample = ApolloExamplePlugin.getInstance().getTitleExample();
+        if (args.length != 1) {
+            player.sendMessage("Usage: /title <display|displayInterpolated|reset>");
+            player.sendMessage("Usage: /title <clearOnServerSwitch> <value>");
+            return true;
+        }
 
         switch (args[0].toLowerCase()) {
             case "display": {
@@ -70,6 +78,7 @@ public class TitleCommand implements CommandExecutor {
 
             default: {
                 player.sendMessage("Usage: /title <display|displayInterpolated|reset>");
+                player.sendMessage("Usage: /title <clearOnServerSwitch> <value>");
                 break;
             }
         }

--- a/bukkit-example-common/src/main/java/com/lunarclient/apollo/example/module/impl/TitleExample.java
+++ b/bukkit-example-common/src/main/java/com/lunarclient/apollo/example/module/impl/TitleExample.java
@@ -34,4 +34,6 @@ public abstract class TitleExample extends ApolloModuleExample {
 
     public abstract void resetTitlesExample(Player viewer);
 
+    public abstract void setClearTitleOnServerSwitch(boolean value);
+
 }

--- a/bukkit-example-json/src/main/java/com/lunarclient/apollo/example/json/module/TitleJsonExample.java
+++ b/bukkit-example-json/src/main/java/com/lunarclient/apollo/example/json/module/TitleJsonExample.java
@@ -29,6 +29,8 @@ import com.lunarclient.apollo.example.json.util.JsonPacketUtil;
 import com.lunarclient.apollo.example.json.util.JsonUtil;
 import com.lunarclient.apollo.example.module.impl.TitleExample;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -84,6 +86,15 @@ public class TitleJsonExample extends TitleExample {
         message.addProperty("@type", "type.googleapis.com/lunarclient.apollo.title.v1.ResetTitlesMessage");
 
         JsonPacketUtil.sendPacket(viewer, message);
+    }
+
+    @Override
+    public void setClearTitleOnServerSwitch(boolean value) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("clear-title-on-server-switch", value);
+
+        JsonObject message = JsonUtil.createEnableModuleObjectWithType("title", properties);
+        JsonPacketUtil.broadcastPacket(message);
     }
 
 }

--- a/bukkit-example-json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
+++ b/bukkit-example-json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
@@ -65,6 +65,7 @@ public final class JsonPacketUtil {
         CONFIG_MODULE_PROPERTIES.put("server_rule", "override-max-chat-length", false);
         CONFIG_MODULE_PROPERTIES.put("server_rule", "max-chat-length", 256);
         CONFIG_MODULE_PROPERTIES.put("tnt_countdown", "tnt-ticks", 80);
+        CONFIG_MODULE_PROPERTIES.put("title", "clear-title-on-server-switch", false);
         CONFIG_MODULE_PROPERTIES.put("waypoint", "server-handles-waypoints", false);
     }
 

--- a/bukkit-example-proto/src/main/java/com/lunarclient/apollo/example/proto/module/TitleProtoExample.java
+++ b/bukkit-example-proto/src/main/java/com/lunarclient/apollo/example/proto/module/TitleProtoExample.java
@@ -23,6 +23,8 @@
  */
 package com.lunarclient.apollo.example.proto.module;
 
+import com.google.protobuf.Value;
+import com.lunarclient.apollo.configurable.v1.ConfigurableSettings;
 import com.lunarclient.apollo.example.module.impl.TitleExample;
 import com.lunarclient.apollo.example.proto.util.AdventureUtil;
 import com.lunarclient.apollo.example.proto.util.ProtobufPacketUtil;
@@ -31,6 +33,8 @@ import com.lunarclient.apollo.title.v1.DisplayTitleMessage;
 import com.lunarclient.apollo.title.v1.ResetTitlesMessage;
 import com.lunarclient.apollo.title.v1.TitleType;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -84,6 +88,15 @@ public class TitleProtoExample extends TitleExample {
     public void resetTitlesExample(Player viewer) {
         ResetTitlesMessage message = ResetTitlesMessage.getDefaultInstance();
         ProtobufPacketUtil.sendPacket(viewer, message);
+    }
+
+    @Override
+    public void setClearTitleOnServerSwitch(boolean value) {
+        Map<String, Value> properties = new HashMap<>();
+        properties.put("clear-title-on-server-switch", Value.newBuilder().setBoolValue(value).build());
+
+        ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("title", properties);
+        ProtobufPacketUtil.broadcastPacket(settings);
     }
 
 }

--- a/bukkit-example-proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
+++ b/bukkit-example-proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
@@ -72,6 +72,7 @@ public final class ProtobufPacketUtil {
         CONFIG_MODULE_PROPERTIES.put("server_rule", "override-max-chat-length", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("server_rule", "max-chat-length", Value.newBuilder().setNumberValue(256).build());
         CONFIG_MODULE_PROPERTIES.put("tnt_countdown", "tnt-ticks", Value.newBuilder().setNumberValue(80).build());
+        CONFIG_MODULE_PROPERTIES.put("title", "clear-title-on-server-switch", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("waypoint", "server-handles-waypoints", Value.newBuilder().setBoolValue(false).build());
     }
 

--- a/docs/developers/lightweight/json/packet-util.mdx
+++ b/docs/developers/lightweight/json/packet-util.mdx
@@ -47,6 +47,7 @@ static {
     CONFIG_MODULE_PROPERTIES.put("server_rule", "override-max-chat-length", false);
     CONFIG_MODULE_PROPERTIES.put("server_rule", "max-chat-length", 256);
     CONFIG_MODULE_PROPERTIES.put("tnt_countdown", "tnt-ticks", 80);
+    CONFIG_MODULE_PROPERTIES.put("title", "clear-title-on-server-switch", false);
     CONFIG_MODULE_PROPERTIES.put("waypoint", "server-handles-waypoints", false);
 }
 ```

--- a/docs/developers/lightweight/protobuf/packet-util.mdx
+++ b/docs/developers/lightweight/protobuf/packet-util.mdx
@@ -51,6 +51,7 @@ static {
     CONFIG_MODULE_PROPERTIES.put("server_rule", "override-max-chat-length", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("server_rule", "max-chat-length", Value.newBuilder().setNumberValue(256).build());
     CONFIG_MODULE_PROPERTIES.put("tnt_countdown", "tnt-ticks", Value.newBuilder().setNumberValue(80).build());
+    CONFIG_MODULE_PROPERTIES.put("title", "clear-title-on-server-switch", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("waypoint", "server-handles-waypoints", Value.newBuilder().setBoolValue(false).build());
 }
 ```

--- a/docs/developers/modules/title.mdx
+++ b/docs/developers/modules/title.mdx
@@ -256,3 +256,11 @@ public void resetTitlesExample(Player viewer) {
 </Tab>
 
 </Tabs>
+
+## Available options
+
+- __`CLEAR_TITLE_ON_SERVER_SWITCH`__
+    - Determines whether the players displayed title should clear when switching servers.
+    - Values
+        - Type: `Boolean`
+        - Default: `false`

--- a/docs/developers/modules/title.mdx
+++ b/docs/developers/modules/title.mdx
@@ -70,6 +70,14 @@ public void resetTitlesExample(Player viewer) {
 }
 ```
 
+### Clear Title On Server Switch
+
+```java
+public void setClearTitleOnServerSwitch(boolean value) {
+    this.titleModule.getOptions().set(TitleModule.CLEAR_TITLE_ON_SERVER_SWITCH, value);
+}
+```
+
 #### `Title` Options
 
 `.type(TitleType)` is the type of title you want to display. See the [TitleType](#titletype-types) types section for more.
@@ -190,6 +198,18 @@ public void resetTitlesExample(Player viewer) {
 }
 ```
 
+### Clear Title On Server Switch
+
+```java
+public void setClearTitleOnServerSwitch(boolean value) {
+    Map<String, Value> properties = new HashMap<>();
+    properties.put("clear-title-on-server-switch", Value.newBuilder().setBoolValue(value).build());
+
+    ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("title", properties);
+    ProtobufPacketUtil.broadcastPacket(settings);
+}
+```
+
 </Tab>
 
 <Tab>
@@ -250,6 +270,18 @@ public void resetTitlesExample(Player viewer) {
     message.addProperty("@type", "type.googleapis.com/lunarclient.apollo.title.v1.ResetTitlesMessage");
 
     JsonPacketUtil.sendPacket(viewer, message);
+}
+```
+
+### Clear Title On Server Switch
+
+```java
+public void setClearTitleOnServerSwitch(boolean value) {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("clear-title-on-server-switch", value);
+
+    JsonObject message = JsonUtil.createEnableModuleObjectWithType("title", properties);
+    JsonPacketUtil.broadcastPacket(message);
 }
 ```
 

--- a/docs/developers/modules/title.mdx
+++ b/docs/developers/modules/title.mdx
@@ -198,7 +198,7 @@ public void resetTitlesExample(Player viewer) {
 }
 ```
 
-### Clear Title On Server Switch
+**Clear Title On Server Switch**
 
 ```java
 public void setClearTitleOnServerSwitch(boolean value) {
@@ -273,7 +273,7 @@ public void resetTitlesExample(Player viewer) {
 }
 ```
 
-### Clear Title On Server Switch
+**Clear Title On Server Switch**
 
 ```java
 public void setClearTitleOnServerSwitch(boolean value) {


### PR DESCRIPTION
## Overview

**Description:**
Adds a `CLEAR_TITLE_ON_SERVER_SWITCH` option to the **Title Module** allowing titles to be automatically cleared when a player switches servers.

**Changes:**
Available options

- __`CLEAR_TITLE_ON_SERVER_SWITCH`__
    - Determines whether the players displayed title should clear when switching servers.
    - Values
        - Type: `Boolean`
        - Default: `false`

**Code Example**

## API

```java
public void setClearTitleOnServerSwitch(boolean value) {
    this.titleModule.getOptions().set(TitleModule.CLEAR_TITLE_ON_SERVER_SWITCH, value);
}
```

## Lightweight

### Proto

```java
public void setClearTitleOnServerSwitch(boolean value) {
    Map<String, Value> properties = new HashMap<>();
    properties.put("clear-title-on-server-switch", Value.newBuilder().setBoolValue(value).build());

    ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("title", properties);
    ProtobufPacketUtil.broadcastPacket(settings);
}
```

### JSON

```java
public void setClearTitleOnServerSwitch(boolean value) {
    Map<String, Object> properties = new HashMap<>();
    properties.put("clear-title-on-server-switch", value);

    JsonObject message = JsonUtil.createEnableModuleObjectWithType("title", properties);
    JsonPacketUtil.broadcastPacket(message);
}
```

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
