### PR TITLE
Feature - User Metadata

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -7,7 +7,7 @@ setupPlatforms()
 
 setupPlatformDependency("bukkit", "bukkitJar")
 setupPlatformDependency("bungee", "bungeeJar")
-setupPlatformDependency("velocity", "velocityJar")
+setupPlatformDependency("velocity", "velocityJar", 17)
 setupPlatformDependency("folia", "foliaJar", 21)
 
 val main by sourceSets

--- a/build-logic/src/main/kotlin/apollo.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/apollo.base-conventions.gradle.kts
@@ -1,4 +1,6 @@
 import com.diffplug.gradle.spotless.FormatExtension
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.regex.Pattern
@@ -83,6 +85,11 @@ checkstyle {
 
 tasks {
     javadoc {
+        val javaToolchains = project.extensions.getByType(JavaToolchainService::class.java)
+        javadocTool.set(javaToolchains.javadocToolFor {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        })
+
         val minimalOptions: MinimalJavadocOptions = options
         options.encoding("UTF-8")
 

--- a/bukkit/src/main/java/com/lunarclient/apollo/ApolloBukkitPlatform.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/ApolloBukkitPlatform.java
@@ -25,9 +25,11 @@ package com.lunarclient.apollo;
 
 import com.lunarclient.apollo.command.impl.ApolloCommand;
 import com.lunarclient.apollo.command.impl.LunarClientCommand;
+import com.lunarclient.apollo.listener.ApolloMetadataListener;
 import com.lunarclient.apollo.listener.ApolloPlayerListener;
 import com.lunarclient.apollo.listener.ApolloWorldListener;
 import com.lunarclient.apollo.loader.PlatformPlugin;
+import com.lunarclient.apollo.metadata.BukkitMetadataManager;
 import com.lunarclient.apollo.module.ApolloModuleManagerImpl;
 import com.lunarclient.apollo.module.autotexthotkey.AutoTextHotkeyModule;
 import com.lunarclient.apollo.module.beam.BeamModule;
@@ -119,7 +121,9 @@ public final class ApolloBukkitPlatform implements PlatformPlugin, ApolloPlatfor
         this.stats = new BukkitApolloStats();
 
         ApolloManager.bootstrap(this);
+        ApolloManager.setMetadataManager(new BukkitMetadataManager());
 
+        new ApolloMetadataListener(this.plugin);
         new ApolloPlayerListener(this.plugin);
         new ApolloWorldListener(this.plugin);
 

--- a/bukkit/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.listener;
+
+import com.lunarclient.apollo.ApolloManager;
+import com.lunarclient.apollo.metadata.BukkitMetadataManager;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.logging.Level;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerResourcePackStatusEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.messaging.Messenger;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+
+/**
+ * Handles Apollo metadata listeners.
+ *
+ * @since 1.1.9
+ */
+public final class ApolloMetadataListener implements Listener {
+
+    private final JavaPlugin plugin;
+
+    /**
+     * Constructs the {@link ApolloMetadataListener}.
+     *
+     * @param plugin the plugin
+     * @since 1.1.9
+     */
+    public ApolloMetadataListener(JavaPlugin plugin) {
+        this.plugin = plugin;
+
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+
+        this.registerIncomingPluginChannel("MC|Brand", "minecraft:brand", (channel, player, bytes) -> {
+            String brand = new String(bytes, StandardCharsets.UTF_8);
+            this.plugin.getLogger().log(Level.WARNING, player.getName() + " is using client brand: " + brand);
+            BukkitMetadataManager manager = (BukkitMetadataManager) ApolloManager.getMetadataManager();
+            manager.getClientBrands().add(brand);
+        });
+    }
+
+    @EventHandler
+    private void onResourcePackStatus(PlayerResourcePackStatusEvent event) {
+        String status = event.getStatus().name();
+        BukkitMetadataManager manager = (BukkitMetadataManager) ApolloManager.getMetadataManager();
+        Map<String, Integer> statuses = manager.getResourcePackStatuses();
+
+        statuses.put(status, statuses.getOrDefault(status, 0) + 1);
+
+        statuses.forEach((key, value) -> {
+            this.plugin.getLogger().log(Level.INFO, "Resource Pack Status: " + key + " - Count: " + value);
+        });
+    }
+
+    private void registerIncomingPluginChannel(String legacyChannel, String modernChannel, PluginMessageListener listener) {
+        Messenger messenger = this.plugin.getServer().getMessenger();
+
+        try {
+            messenger.registerIncomingPluginChannel(this.plugin, legacyChannel, listener);
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        messenger.registerIncomingPluginChannel(this.plugin, modernChannel, listener);
+    }
+
+}

--- a/bukkit/src/main/java/com/lunarclient/apollo/metadata/BukkitMetadata.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/metadata/BukkitMetadata.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.metadata;
+
+import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
+import java.util.Map;
+import java.util.Set;
+import lombok.Builder;
+import lombok.ToString;
+
+/**
+ * Represents the bukkit metadata implementation.
+ *
+ * @since 1.1.9
+ */
+@ToString
+@Builder(toBuilder = true)
+public class BukkitMetadata extends PlatformMetadata {
+
+    /**
+     * Tracks client brands sent by the players.
+     *
+     * <p>A {@link Set} of {@link String} client brands.</p>
+     *
+     * @since 1.1.9
+     */
+    private final Set<String> clientBrands;
+
+    /**
+     * Tracks the total number of resource pack status events received.
+     *
+     * <p>Represents a {@link Map} of {@link String} status enum name as a key
+     * and {@link Integer} count of how many times that status has been reported.</p>
+     *
+     * @since 1.1.9
+     */
+    private final Map<String, Integer> resourcePackStatuses;
+
+}

--- a/bukkit/src/main/java/com/lunarclient/apollo/metadata/BukkitMetadataManager.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/metadata/BukkitMetadataManager.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.metadata;
+
+import com.lunarclient.apollo.stats.metadata.ApolloMetadataManager;
+import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+
+/**
+ * The Bukkit implementation of {@link ApolloMetadataManager}.
+ *
+ * @since 1.1.9
+ */
+@Getter
+public class BukkitMetadataManager implements ApolloMetadataManager {
+
+    private final Set<String> clientBrands = new HashSet<>();
+    private final Map<String, Integer> resourcePackStatuses = new HashMap<>();
+
+    @Override
+    public PlatformMetadata extract() {
+        return BukkitMetadata.builder()
+            .clientBrands(new HashSet<>(this.clientBrands))
+            .resourcePackStatuses(new HashMap<>(this.resourcePackStatuses))
+            .build();
+    }
+
+    @Override
+    public void clear() {
+        this.clientBrands.clear();
+        this.resourcePackStatuses.clear();
+    }
+}

--- a/bukkit/src/main/java/com/lunarclient/apollo/util/ByteBufUtil.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/util/ByteBufUtil.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.util;
+
+import com.google.common.io.ByteArrayDataInput;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Represents a util for reading byte buffs.
+ *
+ * @since 1.1.9
+ */
+public final class ByteBufUtil {
+
+    /**
+     * Reads an int from the given input stream.
+     *
+     * @param in in the {@link ByteArrayDataInput} to read from
+     * @return the read int
+     * @throws IllegalArgumentException if the value length is invalid or too large
+     * @since 1.1.9
+     */
+    public static int readVarInt(ByteArrayDataInput in) {
+        int i = 0;
+        int j = 0;
+
+        while (true) {
+            byte b = in.readByte();
+            i |= (b & 0x7F) << j++ * 7;
+
+            if (j > 5) {
+                throw new RuntimeException("VarInt too big");
+            }
+
+            if ((b & 0x80) != 128) {
+                break;
+            }
+        }
+
+        return i;
+    }
+
+    /**
+     * Reads a UTF-8 encoded string from the given input stream.
+     *
+     * @param in the {@link ByteArrayDataInput} to read from
+     * @return the decoded string
+     * @throws IllegalArgumentException if the value length is invalid or too large
+     * @since 1.1.9
+     */
+    public static String readString(ByteArrayDataInput in) {
+        int length = ByteBufUtil.readVarInt(in);
+        byte[] bytes = new byte[length];
+        in.readFully(bytes);
+
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private ByteBufUtil() {
+    }
+
+}

--- a/bungee/src/main/java/com/lunarclient/apollo/ApolloBungeePlatform.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/ApolloBungeePlatform.java
@@ -25,8 +25,10 @@ package com.lunarclient.apollo;
 
 import com.lunarclient.apollo.command.impl.ApolloCommand;
 import com.lunarclient.apollo.command.impl.LunarClientCommand;
+import com.lunarclient.apollo.listener.ApolloMetadataListener;
 import com.lunarclient.apollo.listener.ApolloPlayerListener;
 import com.lunarclient.apollo.loader.PlatformPlugin;
+import com.lunarclient.apollo.metadata.BungeeMetadataManager;
 import com.lunarclient.apollo.module.ApolloModuleManagerImpl;
 import com.lunarclient.apollo.module.autotexthotkey.AutoTextHotkeyModule;
 import com.lunarclient.apollo.module.beam.BeamModule;
@@ -107,6 +109,7 @@ public final class ApolloBungeePlatform implements PlatformPlugin, ApolloPlatfor
         this.stats = new BungeeApolloStats();
 
         ApolloManager.bootstrap(this);
+        ApolloManager.setMetadataManager(new BungeeMetadataManager());
 
         ((ApolloModuleManagerImpl) Apollo.getModuleManager())
             .addModule(AutoTextHotkeyModule.class)
@@ -146,6 +149,7 @@ public final class ApolloBungeePlatform implements PlatformPlugin, ApolloPlatfor
         server.registerChannel(ApolloManager.PLUGIN_MESSAGE_CHANNEL);
 
         PluginManager pluginManager = server.getPluginManager();
+        pluginManager.registerListener(this.plugin, new ApolloMetadataListener(this.plugin));
         pluginManager.registerListener(this.plugin, new ApolloPlayerListener());
         pluginManager.registerCommand(this.plugin, ApolloCommand.create());
         pluginManager.registerCommand(this.plugin, LunarClientCommand.create());

--- a/bungee/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.listener;
+
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteStreams;
+import com.lunarclient.apollo.ApolloBungeePlatform;
+import com.lunarclient.apollo.ApolloManager;
+import com.lunarclient.apollo.metadata.BungeeMetadataManager;
+import com.lunarclient.apollo.util.ByteBufUtil;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.connection.Connection;
+import net.md_5.bungee.api.connection.PendingConnection;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.PluginMessageEvent;
+import net.md_5.bungee.api.event.PreLoginEvent;
+import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.event.EventHandler;
+
+/**
+ * Handles Apollo metadata listeners.
+ *
+ * @since 1.1.9
+ */
+public final class ApolloMetadataListener implements Listener {
+
+    /**
+     * Constructs the {@link ApolloMetadataListener}.
+     *
+     * @param plugin the plugin
+     * @since 1.1.9
+     */
+    public ApolloMetadataListener(Plugin plugin) {
+        ProxyServer server = plugin.getProxy();
+
+        server.registerChannel("MC|Brand");
+        server.registerChannel("minecraft:brand");
+
+        server.registerChannel("FML|HS");
+        server.registerChannel("fml:handshake");
+    }
+
+    /**
+     * Handles plugin messages for client brand and FML mod information.
+     *
+     * @param event the event
+     * @since 1.1.9
+     */
+    @EventHandler
+    public void onPluginMessage(PluginMessageEvent event) {
+        String tag = event.getTag();
+
+        if (tag.equals("minecraft:brand") || tag.equals("MC|Brand")) {
+            this.handleBrand(event.getData(), event.getSender());
+            return;
+        }
+
+        if (tag.equals("fml:handshake") || tag.equals("FML|HS")) {
+            this.handleFml(event.getData(), event.getSender());
+        }
+    }
+
+    /**
+     * Captures the server IP and port the player used to connect.
+     *
+     * @param event the event
+     * @since 1.1.9
+     */
+    @EventHandler
+    public void onPreLogin(PreLoginEvent event) {
+        PendingConnection connection = event.getConnection();
+        InetSocketAddress host = connection.getVirtualHost();
+
+        if (host == null) {
+            return;
+        }
+
+        BungeeMetadataManager manager = (BungeeMetadataManager) ApolloManager.getMetadataManager();
+        manager.getServerAddress().add(host.getAddress().getHostAddress() + ":" + host.getPort());
+        ApolloBungeePlatform.getInstance().getPlatformLogger().log(Level.WARNING, host.getAddress().getHostAddress() + ":" + host.getPort());
+    }
+
+    private void handleBrand(byte[] data, Connection sender) {
+        if (!(sender instanceof ProxiedPlayer)) {
+            System.out.println("Not a player Brand");
+            return;
+        }
+
+        String brand = new String(data, StandardCharsets.UTF_8);
+        ApolloBungeePlatform.getInstance().getPlatformLogger().log(Level.WARNING, ((ProxiedPlayer) sender).getName() + " is using client brand: " + brand);
+
+        BungeeMetadataManager manager = (BungeeMetadataManager) ApolloManager.getMetadataManager();
+        manager.getClientBrands().add(brand);
+    }
+
+    private void handleFml(byte[] data, Connection sender) {
+        if (!(sender instanceof ProxiedPlayer)) {
+            System.out.println("Not a player FML");
+            return;
+        }
+
+        ProxiedPlayer player = (ProxiedPlayer) sender;
+
+        ByteArrayDataInput in = ByteStreams.newDataInput(data);
+        byte discriminator = in.readByte();
+
+        if (discriminator != 2) {
+            System.out.println("Discriminator is not 2: " + discriminator);
+            return;
+        }
+
+        int count = ByteBufUtil.readVarInt(in);
+
+        for (int i = 0; i < count; i++) {
+            String modId = ByteBufUtil.readString(in);
+            String version = ByteBufUtil.readString(in);
+
+            ApolloBungeePlatform.getInstance().getPlatformLogger().log(Level.WARNING, player.getName() + " is using mod: " + modId + " with version: " + version);
+            BungeeMetadataManager manager = (BungeeMetadataManager) ApolloManager.getMetadataManager();
+            manager.getMods().put(modId, version);
+        }
+    }
+
+}

--- a/bungee/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
@@ -73,15 +73,21 @@ public final class ApolloMetadataListener implements Listener {
      */
     @EventHandler
     public void onPluginMessage(PluginMessageEvent event) {
+        if (!(event.getSender() instanceof ProxiedPlayer)) {
+            System.out.println("Not a player Brand");
+            return;
+        }
+
+        ProxiedPlayer player = (ProxiedPlayer) event.getSender();
         String tag = event.getTag();
 
         if (tag.equals("minecraft:brand") || tag.equals("MC|Brand")) {
-            this.handleBrand(event.getData(), event.getSender());
+            this.handleBrand(event.getData(), player);
             return;
         }
 
         if (tag.equals("fml:handshake") || tag.equals("FML|HS")) {
-            this.handleFml(event.getData(), event.getSender());
+            this.handleFml(event.getData(), player);
         }
     }
 
@@ -100,17 +106,20 @@ public final class ApolloMetadataListener implements Listener {
             return;
         }
 
+        String hostString;
+
+        if (host.getAddress() != null) {
+            hostString = host.getAddress().getHostAddress();
+        } else {
+            hostString = host.getHostName();
+        }
+
         BungeeMetadataManager manager = (BungeeMetadataManager) ApolloManager.getMetadataManager();
-        manager.getServerAddress().add(host.getAddress().getHostAddress() + ":" + host.getPort());
-        ApolloBungeePlatform.getInstance().getPlatformLogger().log(Level.WARNING, host.getAddress().getHostAddress() + ":" + host.getPort());
+        manager.getServerAddress().add(hostString + ":" + host.getPort());
+        ApolloBungeePlatform.getInstance().getPlatformLogger().log(Level.WARNING, hostString + ":" + host.getPort());
     }
 
     private void handleBrand(byte[] data, Connection sender) {
-        if (!(sender instanceof ProxiedPlayer)) {
-            System.out.println("Not a player Brand");
-            return;
-        }
-
         String brand = new String(data, StandardCharsets.UTF_8);
         ApolloBungeePlatform.getInstance().getPlatformLogger().log(Level.WARNING, ((ProxiedPlayer) sender).getName() + " is using client brand: " + brand);
 
@@ -119,18 +128,12 @@ public final class ApolloMetadataListener implements Listener {
     }
 
     private void handleFml(byte[] data, Connection sender) {
-        if (!(sender instanceof ProxiedPlayer)) {
-            System.out.println("Not a player FML");
-            return;
-        }
-
         ProxiedPlayer player = (ProxiedPlayer) sender;
 
         ByteArrayDataInput in = ByteStreams.newDataInput(data);
         byte discriminator = in.readByte();
 
         if (discriminator != 2) {
-            System.out.println("Discriminator is not 2: " + discriminator);
             return;
         }
 

--- a/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadata.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadata.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.metadata;
+
+import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
+import lombok.Builder;
+import lombok.ToString;
+import java.util.Set;
+
+/**
+ * Represents the bungee metadata implementation.
+ *
+ * @since 1.1.9
+ */
+@ToString
+@Builder(toBuilder = true)
+public class BungeeMetadata extends PlatformMetadata {
+
+    /**
+     * Tracks client brands sent by the players.
+     *
+     * <p>A {@link Set} of {@link String} client brands.</p>
+     *
+     * @since 1.1.9
+     */
+    private final Set<String> clientBrands;
+
+}

--- a/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadata.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadata.java
@@ -24,9 +24,10 @@
 package com.lunarclient.apollo.metadata;
 
 import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
+import java.util.Map;
+import java.util.Set;
 import lombok.Builder;
 import lombok.ToString;
-import java.util.Set;
 
 /**
  * Represents the bungee metadata implementation.
@@ -45,5 +46,24 @@ public class BungeeMetadata extends PlatformMetadata {
      * @since 1.1.9
      */
     private final Set<String> clientBrands;
+
+    /**
+     * Tracks forge mods sent with the forge handshake.
+     *
+     * <p>A {@link Map} of {@link String} mod id
+     * as a key and {@link String} version as value.</p>
+     *
+     * @since 1.1.9
+     */
+    private final Map<String, String> mods;
+
+    /**
+     * Tracks the server IP and port the player used to connect.
+     *
+     * <p>A {@link Set} of {@link String} server addresses in the format: <code>host:port</code></p>
+     *
+     * @since 1.1.9
+     */
+    private final Set<String> serverAddress;
 
 }

--- a/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadataManager.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadataManager.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.metadata;
+
+import com.lunarclient.apollo.stats.metadata.ApolloMetadataManager;
+import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The Bungee implementation of {@link ApolloMetadataManager}.
+ *
+ * @since 1.1.9
+ */
+@Getter
+public class BungeeMetadataManager implements ApolloMetadataManager {
+
+    private final Set<String> clientBrands = new HashSet<>();
+    private final Map<String, String> mods = new HashMap<>();
+    private final Set<String> serverAddress = new HashSet<>();
+
+    @Override
+    public PlatformMetadata extract() {
+        return BungeeMetadata.builder()
+            .clientBrands(new HashSet<>(this.clientBrands))
+            .build();
+    }
+
+    @Override
+    public void clear() {
+        this.clientBrands.clear();
+    }
+}

--- a/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadataManager.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadataManager.java
@@ -25,12 +25,11 @@ package com.lunarclient.apollo.metadata;
 
 import com.lunarclient.apollo.stats.metadata.ApolloMetadataManager;
 import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
-import lombok.Getter;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import lombok.Getter;
 
 /**
  * The Bungee implementation of {@link ApolloMetadataManager}.
@@ -48,11 +47,16 @@ public class BungeeMetadataManager implements ApolloMetadataManager {
     public PlatformMetadata extract() {
         return BungeeMetadata.builder()
             .clientBrands(new HashSet<>(this.clientBrands))
+            .mods(new HashMap<>(this.mods))
+            .serverAddress(new HashSet<>(this.serverAddress))
             .build();
     }
 
     @Override
     public void clear() {
         this.clientBrands.clear();
+        this.mods.clear();
+        this.serverAddress.clear();
     }
+
 }

--- a/bungee/src/main/java/com/lunarclient/apollo/util/ByteBufUtil.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/util/ByteBufUtil.java
@@ -33,6 +33,14 @@ import java.nio.charset.StandardCharsets;
  */
 public final class ByteBufUtil {
 
+    /**
+     * Reads an int from the given input stream.
+     *
+     * @param in in the {@link ByteArrayDataInput} to read from
+     * @return the read int
+     * @throws IllegalArgumentException if the value length is invalid or too large
+     * @since 1.1.9
+     */
     public static int readVarInt(ByteArrayDataInput in) {
         int i = 0;
         int j = 0;
@@ -53,6 +61,14 @@ public final class ByteBufUtil {
         return i;
     }
 
+    /**
+     * Reads a UTF-8 encoded string from the given input stream.
+     *
+     * @param in the {@link ByteArrayDataInput} to read from
+     * @return the decoded string
+     * @throws IllegalArgumentException if the value length is invalid or too large
+     * @since 1.1.9
+     */
     public static String readString(ByteArrayDataInput in) {
         int length = ByteBufUtil.readVarInt(in);
         byte[] bytes = new byte[length];

--- a/bungee/src/main/java/com/lunarclient/apollo/util/ByteBufUtil.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/util/ByteBufUtil.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.util;
+
+import com.google.common.io.ByteArrayDataInput;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Represents a util for reading byte buffs.
+ *
+ * @since 1.1.9
+ */
+public final class ByteBufUtil {
+
+    public static int readVarInt(ByteArrayDataInput in) {
+        int i = 0;
+        int j = 0;
+
+        while (true) {
+            byte b = in.readByte();
+            i |= (b & 0x7F) << j++ * 7;
+
+            if (j > 5) {
+                throw new RuntimeException("VarInt too big");
+            }
+
+            if ((b & 0x80) != 128) {
+                break;
+            }
+        }
+
+        return i;
+    }
+
+    public static String readString(ByteArrayDataInput in) {
+        int length = ByteBufUtil.readVarInt(in);
+        byte[] bytes = new byte[length];
+        in.readFully(bytes);
+
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private ByteBufUtil() {
+    }
+
+}

--- a/common/src/main/java/com/lunarclient/apollo/ApolloManager.java
+++ b/common/src/main/java/com/lunarclient/apollo/ApolloManager.java
@@ -34,6 +34,7 @@ import com.lunarclient.apollo.option.config.CommonSerializers;
 import com.lunarclient.apollo.player.ApolloPlayerManagerImpl;
 import com.lunarclient.apollo.roundtrip.ApolloRoundtripManager;
 import com.lunarclient.apollo.stats.ApolloStatsManager;
+import com.lunarclient.apollo.stats.metadata.ApolloMetadataManager;
 import com.lunarclient.apollo.util.ConfigTarget;
 import com.lunarclient.apollo.version.ApolloVersionManager;
 import com.lunarclient.apollo.world.ApolloWorldManagerImpl;
@@ -42,6 +43,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Provides the instances for {@link Apollo}.
@@ -74,6 +76,7 @@ public final class ApolloManager {
     @Getter private static ApolloNetworkManager networkManager;
     @Getter private static ApolloVersionManager versionManager;
     @Getter private static ApolloStatsManager statsManager;
+    @Getter @Setter private static ApolloMetadataManager metadataManager;
 
     @Getter private static Path configPath;
 

--- a/common/src/main/java/com/lunarclient/apollo/api/ApolloHttpManager.java
+++ b/common/src/main/java/com/lunarclient/apollo/api/ApolloHttpManager.java
@@ -81,6 +81,13 @@ public final class ApolloHttpManager {
         ApiRequestType requestType = request.getType();
         Type responseType = request.getResponseType();
 
+        System.out.println("Request:");
+        System.out.println(ApolloManager.GSON.toJson(request));
+
+        if (true) {
+            return future;
+        }
+
         this.requestExecutor.submit(() -> {
             try {
                 URL url = new URL("https://" + request.getService().getUrl() + request.getRoute());

--- a/common/src/main/java/com/lunarclient/apollo/api/ApolloHttpManager.java
+++ b/common/src/main/java/com/lunarclient/apollo/api/ApolloHttpManager.java
@@ -81,13 +81,6 @@ public final class ApolloHttpManager {
         ApiRequestType requestType = request.getType();
         Type responseType = request.getResponseType();
 
-        System.out.println("Request:");
-        System.out.println(ApolloManager.GSON.toJson(request));
-
-        if (true) {
-            return future;
-        }
-
         this.requestExecutor.submit(() -> {
             try {
                 URL url = new URL("https://" + request.getService().getUrl() + request.getRoute());

--- a/common/src/main/java/com/lunarclient/apollo/api/request/heartbeat/ServerHeartbeatRequest.java
+++ b/common/src/main/java/com/lunarclient/apollo/api/request/heartbeat/ServerHeartbeatRequest.java
@@ -21,12 +21,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.lunarclient.apollo.api.request;
+package com.lunarclient.apollo.api.request.heartbeat;
 
 import com.lunarclient.apollo.api.ApiRequest;
 import com.lunarclient.apollo.api.ApiRequestType;
 import com.lunarclient.apollo.api.ApiServiceType;
 import com.lunarclient.apollo.api.response.ServerHeartbeatResponse;
+import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
 import lombok.Builder;
 import lombok.ToString;
 
@@ -80,6 +81,13 @@ public final class ServerHeartbeatRequest implements ApiRequest<ServerHeartbeatR
      * @since 1.0.0
      */
     private final int totalPlayers;
+
+    /**
+     * The platform specific user metadata.
+     *
+     * @since 1.1.9
+     */
+    private final PlatformMetadata metadata;
 
     @Override
     public ApiServiceType getService() {

--- a/common/src/main/java/com/lunarclient/apollo/stats/ApolloStatsManager.java
+++ b/common/src/main/java/com/lunarclient/apollo/stats/ApolloStatsManager.java
@@ -36,14 +36,12 @@ import io.leangen.geantyref.TypeToken;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.Getter;
 
 /**
  * Manages Apollo statistics.
  *
  * @since 1.0.0
  */
-@Getter
 public final class ApolloStatsManager {
 
     public static final String SESSION_ID = UUID.randomUUID().toString();
@@ -85,7 +83,7 @@ public final class ApolloStatsManager {
         .defaultValue(true).build();
 
     public static final SimpleOption<Boolean> HEARTBEAT_USER_METADATA = Option.<Boolean>builder()
-        .comment("Set to 'true' to send players user metadata such as TODO to MCStats, otherwise 'false'.")
+        .comment("Set to 'true' to send players user metadata to MCStats, otherwise 'false'.")
         .node(CONFIG_PREFIX, "user-metadata").type(TypeToken.get(Boolean.class))
         .defaultValue(true).build();
 

--- a/common/src/main/java/com/lunarclient/apollo/stats/ApolloStatsManager.java
+++ b/common/src/main/java/com/lunarclient/apollo/stats/ApolloStatsManager.java
@@ -36,12 +36,14 @@ import io.leangen.geantyref.TypeToken;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.Getter;
 
 /**
  * Manages Apollo statistics.
  *
  * @since 1.0.0
  */
+@Getter
 public final class ApolloStatsManager {
 
     public static final String SESSION_ID = UUID.randomUUID().toString();
@@ -82,6 +84,11 @@ public final class ApolloStatsManager {
         .node(CONFIG_PREFIX, "counts").type(TypeToken.get(Boolean.class))
         .defaultValue(true).build();
 
+    public static final SimpleOption<Boolean> HEARTBEAT_USER_METADATA = Option.<Boolean>builder()
+        .comment("Set to 'true' to send players user metadata such as TODO to MCStats, otherwise 'false'.")
+        .node(CONFIG_PREFIX, "user-metadata").type(TypeToken.get(Boolean.class))
+        .defaultValue(true).build();
+
     /**
      * Constructs the {@link ApolloStatsManager}.
      *
@@ -95,7 +102,8 @@ public final class ApolloStatsManager {
             ApolloStatsManager.HARDWARE_INFORMATION,
             ApolloStatsManager.SOFTWARE_INFORMATION,
             ApolloStatsManager.HEARTBEAT_PERFORMANCE,
-            ApolloStatsManager.HEARTBEAT_COUNTS
+            ApolloStatsManager.HEARTBEAT_COUNTS,
+            ApolloStatsManager.HEARTBEAT_USER_METADATA
         );
     }
 

--- a/common/src/main/java/com/lunarclient/apollo/stats/ApolloStatsThread.java
+++ b/common/src/main/java/com/lunarclient/apollo/stats/ApolloStatsThread.java
@@ -43,7 +43,7 @@ public final class ApolloStatsThread extends Thread {
 
     private static final long MB_BYTES = 1024 * 1024;
     private static final OperatingSystemMXBean MX_BEAN = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);
-    private static final long HEARTBEAT_INTERVAL = TimeUnit.MINUTES.toMillis(2);
+    private static final long HEARTBEAT_INTERVAL = TimeUnit.MINUTES.toMillis(15);
 
     /**
      * Constructs the {@link ApolloStatsThread} thread.
@@ -99,12 +99,8 @@ public final class ApolloStatsThread extends Thread {
 
                     requestBuilder
                         .metadata(metadataManager.extract());
-                    System.out.println("Metadata");
-                    System.out.println(metadataManager.extract());
 
                     metadataManager.clear();
-                    System.out.println("After clear");
-                    System.out.println(metadataManager.extract());
                 }
 
                 final ServerHeartbeatRequest finalRequest = request = requestBuilder.build();

--- a/common/src/main/java/com/lunarclient/apollo/stats/metadata/ApolloMetadataManager.java
+++ b/common/src/main/java/com/lunarclient/apollo/stats/metadata/ApolloMetadataManager.java
@@ -23,15 +23,12 @@
  */
 package com.lunarclient.apollo.stats.metadata;
 
-import org.jetbrains.annotations.ApiStatus;
-
 /**
  * Represents the Apollo metadata manager, responsible for
  * managing and extracting metadata related to the platform.
  *
  * @since 1.1.9
  */
-@ApiStatus.NonExtendable
 public interface ApolloMetadataManager {
 
     /**

--- a/common/src/main/java/com/lunarclient/apollo/stats/metadata/ApolloMetadataManager.java
+++ b/common/src/main/java/com/lunarclient/apollo/stats/metadata/ApolloMetadataManager.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.stats.metadata;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Represents the Apollo metadata manager, responsible for
+ * managing and extracting metadata related to the platform.
+ *
+ * @since 1.1.9
+ */
+@ApiStatus.NonExtendable
+public interface ApolloMetadataManager {
+
+    /**
+     * Extract the current platform metadata.
+     *
+     * @return the platform metadata object
+     * @since 1.1.9
+     */
+    PlatformMetadata extract();
+
+    /**
+     * Clears the current metadata cache.
+     *
+     * @since 1.1.9
+     */
+    void clear();
+
+}

--- a/common/src/main/java/com/lunarclient/apollo/stats/metadata/PlatformMetadata.java
+++ b/common/src/main/java/com/lunarclient/apollo/stats/metadata/PlatformMetadata.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.stats.metadata;
+
+/**
+ * Represents the base class for platform specific metadata.
+ *
+ * @since 1.1.9
+ */
+public abstract class PlatformMetadata {
+}

--- a/folia/src/main/java/com/lunarclient/apollo/ApolloFoliaPlatform.java
+++ b/folia/src/main/java/com/lunarclient/apollo/ApolloFoliaPlatform.java
@@ -25,8 +25,10 @@ package com.lunarclient.apollo;
 
 import com.lunarclient.apollo.command.impl.ApolloCommand;
 import com.lunarclient.apollo.command.impl.LunarClientCommand;
+import com.lunarclient.apollo.listener.ApolloMetadataListener;
 import com.lunarclient.apollo.listener.ApolloPlayerListener;
 import com.lunarclient.apollo.listener.ApolloWorldListener;
+import com.lunarclient.apollo.metadata.FoliaMetadataManager;
 import com.lunarclient.apollo.module.ApolloModuleManagerImpl;
 import com.lunarclient.apollo.module.autotexthotkey.AutoTextHotkeyModule;
 import com.lunarclient.apollo.module.beam.BeamModule;
@@ -109,7 +111,9 @@ public final class ApolloFoliaPlatform extends JavaPlugin implements ApolloPlatf
         this.stats = new FoliaApolloStats();
 
         ApolloManager.bootstrap(this);
+        ApolloManager.setMetadataManager(new FoliaMetadataManager());
 
+        new ApolloMetadataListener(this);
         new ApolloPlayerListener(this);
         new ApolloWorldListener(this);
 

--- a/folia/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
+++ b/folia/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
@@ -24,16 +24,15 @@
 package com.lunarclient.apollo.listener;
 
 import com.lunarclient.apollo.ApolloManager;
-import com.lunarclient.apollo.metadata.BukkitMetadataManager;
-import java.nio.charset.StandardCharsets;
+import com.lunarclient.apollo.metadata.FoliaMetadataManager;
 import java.util.Map;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.plugin.messaging.Messenger;
-import org.bukkit.plugin.messaging.PluginMessageListener;
 
 /**
  * Handles Apollo metadata listeners.
@@ -53,35 +52,35 @@ public final class ApolloMetadataListener implements Listener {
     public ApolloMetadataListener(JavaPlugin plugin) {
         this.plugin = plugin;
 
-        this.registerBrandListener();
         Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    private void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+
+        Bukkit.getGlobalRegionScheduler().runDelayed(this.plugin, t -> {
+            if (!player.isOnline()) {
+                return;
+            }
+
+            String brand = player.getClientBrandName();
+            if (brand == null) {
+                return;
+            }
+
+            FoliaMetadataManager manager = (FoliaMetadataManager) ApolloManager.getMetadataManager();
+            manager.getClientBrands().add(brand);
+        }, 20L * 3);
     }
 
     @EventHandler
     private void onResourcePackStatus(PlayerResourcePackStatusEvent event) {
         String status = event.getStatus().name();
-        BukkitMetadataManager manager = (BukkitMetadataManager) ApolloManager.getMetadataManager();
+        FoliaMetadataManager manager = (FoliaMetadataManager) ApolloManager.getMetadataManager();
         Map<String, Integer> statuses = manager.getResourcePackStatuses();
 
         statuses.put(status, statuses.getOrDefault(status, 0) + 1);
-    }
-
-    private void registerBrandListener() {
-        PluginMessageListener listener = (channel, player, bytes) -> {
-            String brand = new String(bytes, StandardCharsets.UTF_8);
-
-            BukkitMetadataManager manager = (BukkitMetadataManager) ApolloManager.getMetadataManager();
-            manager.getClientBrands().add(brand);
-        };
-
-        Messenger messenger = this.plugin.getServer().getMessenger();
-
-        try {
-            messenger.registerIncomingPluginChannel(this.plugin, "MC|Brand", listener);
-        } catch (IllegalArgumentException ignored) {
-        }
-
-        messenger.registerIncomingPluginChannel(this.plugin, "minecraft:brand", listener);
     }
 
 }

--- a/folia/src/main/java/com/lunarclient/apollo/metadata/FoliaMetadata.java
+++ b/folia/src/main/java/com/lunarclient/apollo/metadata/FoliaMetadata.java
@@ -23,37 +23,38 @@
  */
 package com.lunarclient.apollo.metadata;
 
-import com.lunarclient.apollo.stats.metadata.ApolloMetadataManager;
 import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import lombok.Getter;
+import lombok.Builder;
+import lombok.ToString;
 
 /**
- * The Bukkit implementation of {@link ApolloMetadataManager}.
+ * Represents the folia metadata implementation.
  *
  * @since 1.1.9
  */
-@Getter
-public class BukkitMetadataManager implements ApolloMetadataManager {
+@ToString
+@Builder(toBuilder = true)
+public class FoliaMetadata extends PlatformMetadata {
 
-    private final Set<String> clientBrands = new HashSet<>();
-    private final Map<String, Integer> resourcePackStatuses = new HashMap<>();
+    /**
+     * Tracks client brands sent by the players.
+     *
+     * <p>A {@link Set} of {@link String} client brands.</p>
+     *
+     * @since 1.1.9
+     */
+    private final Set<String> clientBrands;
 
-    @Override
-    public PlatformMetadata extract() {
-        return BukkitMetadata.builder()
-            .clientBrands(new HashSet<>(this.clientBrands))
-            .resourcePackStatuses(new HashMap<>(this.resourcePackStatuses))
-            .build();
-    }
-
-    @Override
-    public void clear() {
-        this.clientBrands.clear();
-        this.resourcePackStatuses.clear();
-    }
+    /**
+     * Tracks the total number of resource pack status events received.
+     *
+     * <p>Represents a {@link Map} of {@link String} status enum name as a key
+     * and {@link Integer} count of how many times that status has been reported.</p>
+     *
+     * @since 1.1.9
+     */
+    private final Map<String, Integer> resourcePackStatuses;
 
 }

--- a/folia/src/main/java/com/lunarclient/apollo/metadata/FoliaMetadataManager.java
+++ b/folia/src/main/java/com/lunarclient/apollo/metadata/FoliaMetadataManager.java
@@ -29,22 +29,23 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 
 /**
- * The Bukkit implementation of {@link ApolloMetadataManager}.
+ * The Folia implementation of {@link ApolloMetadataManager}.
  *
  * @since 1.1.9
  */
 @Getter
-public class BukkitMetadataManager implements ApolloMetadataManager {
+public class FoliaMetadataManager implements ApolloMetadataManager {
 
-    private final Set<String> clientBrands = new HashSet<>();
-    private final Map<String, Integer> resourcePackStatuses = new HashMap<>();
+    private final Set<String> clientBrands = ConcurrentHashMap.newKeySet();
+    private final Map<String, Integer> resourcePackStatuses = new ConcurrentHashMap<>();
 
     @Override
     public PlatformMetadata extract() {
-        return BukkitMetadata.builder()
+        return FoliaMetadata.builder()
             .clientBrands(new HashSet<>(this.clientBrands))
             .resourcePackStatuses(new HashMap<>(this.resourcePackStatuses))
             .build();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ protobuf = "0.0.2"
 gson = "2.10.1"
 shadow = "8.1.1"
 spotless = "6.13.0"
-velocity = "3.0.1"
+velocity = "3.3.0-SNAPSHOT"
 folia = "1.20.1-R0.1-SNAPSHOT"
 asm = "9.7.1"
 

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     id("apollo.shadow-conventions")
 }
 
+java {
+    javaTarget(17)
+}
+
 dependencies {
     compileOnly(libs.velocity)
 

--- a/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
@@ -221,13 +221,34 @@ public final class ApolloVelocityPlatform implements ApolloPlatform {
         ((ApolloModuleManagerImpl) Apollo.getModuleManager()).disableModules();
     }
 
-    static {
+    /**
+     * Creates a {@link MinecraftChannelIdentifier} in a way that supports both
+     * modern and legacy Velocity APIs.
+     *
+     * @param channel the channel in {@code namespace:key} format (e.g. {@code minecraft:brand})
+     * @return the channel identifier object for the provided channel
+     * @throws IllegalArgumentException if the channel format is invalid
+     * @since 1.1.9
+     */
+    public static MinecraftChannelIdentifier createChannelIdentifier(String channel) {
         try {
-            PLUGIN_CHANNEL = MinecraftChannelIdentifier.from(ApolloManager.PLUGIN_MESSAGE_CHANNEL);
-        } catch (NoSuchMethodError e) {
-            String[] messageChannel = ApolloManager.PLUGIN_MESSAGE_CHANNEL.split(":");
-            PLUGIN_CHANNEL = MinecraftChannelIdentifier.create(messageChannel[0], messageChannel[1]);
+            return MinecraftChannelIdentifier.from(channel);
+        } catch (NoSuchMethodError | IllegalArgumentException e) {
+            if (channel.contains("|")) {
+                return MinecraftChannelIdentifier.create(channel, "");
+            }
+
+            String[] parts = channel.split(":", 2);
+            if (parts.length != 2) {
+                throw new IllegalArgumentException("Invalid channel identifier: " + channel);
+            }
+
+            return MinecraftChannelIdentifier.create(parts[0], parts[1]);
         }
+    }
+
+    static {
+        PLUGIN_CHANNEL = ApolloVelocityPlatform.createChannelIdentifier(ApolloManager.PLUGIN_MESSAGE_CHANNEL);
     }
 
 }

--- a/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
@@ -26,7 +26,9 @@ package com.lunarclient.apollo;
 import com.google.inject.Inject;
 import com.lunarclient.apollo.command.impl.ApolloCommand;
 import com.lunarclient.apollo.command.impl.LunarClientCommand;
+import com.lunarclient.apollo.listener.ApolloMetadataListener;
 import com.lunarclient.apollo.listener.ApolloPlayerListener;
+import com.lunarclient.apollo.metadata.VelocityMetadataManager;
 import com.lunarclient.apollo.module.ApolloModuleManagerImpl;
 import com.lunarclient.apollo.module.autotexthotkey.AutoTextHotkeyModule;
 import com.lunarclient.apollo.module.beam.BeamModule;
@@ -75,6 +77,7 @@ import com.lunarclient.apollo.option.OptionsImpl;
 import com.lunarclient.apollo.stats.ApolloStats;
 import com.lunarclient.apollo.wrapper.VelocityApolloStats;
 import com.velocitypowered.api.command.CommandManager;
+import com.velocitypowered.api.event.EventManager;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
@@ -83,6 +86,7 @@ import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.PluginDescription;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.messages.ChannelRegistrar;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import java.nio.file.Path;
 import java.util.logging.Level;
@@ -163,7 +167,9 @@ public final class ApolloVelocityPlatform implements ApolloPlatform {
     public void onProxyInitialization(ProxyInitializeEvent event) {
         ApolloVelocityPlatform.instance = this;
         this.stats = new VelocityApolloStats();
+
         ApolloManager.bootstrap(this);
+        ApolloManager.setMetadataManager(new VelocityMetadataManager());
 
         ((ApolloModuleManagerImpl) Apollo.getModuleManager())
             .addModule(AutoTextHotkeyModule.class)
@@ -199,8 +205,13 @@ public final class ApolloVelocityPlatform implements ApolloPlatform {
             this.getPlatformLogger().log(Level.SEVERE, "Unable to load Apollo configuration and modules!", throwable);
         }
 
-        this.server.getEventManager().register(this, new ApolloPlayerListener());
-        this.server.getChannelRegistrar().register(ApolloVelocityPlatform.PLUGIN_CHANNEL);
+        EventManager eventManager = this.server.getEventManager();
+        eventManager.register(this, new ApolloMetadataListener());
+        eventManager.register(this, new ApolloPlayerListener());
+
+        ChannelRegistrar channelRegistrar = this.server.getChannelRegistrar();
+        channelRegistrar.register(ApolloVelocityPlatform.PLUGIN_CHANNEL);
+        channelRegistrar.register(ApolloMetadataListener.FML_HANDSHAKE_CHANNEL);
 
         CommandManager commandManager = this.server.getCommandManager();
         commandManager.register(ApolloCommand.create());
@@ -221,34 +232,8 @@ public final class ApolloVelocityPlatform implements ApolloPlatform {
         ((ApolloModuleManagerImpl) Apollo.getModuleManager()).disableModules();
     }
 
-    /**
-     * Creates a {@link MinecraftChannelIdentifier} in a way that supports both
-     * modern and legacy Velocity APIs.
-     *
-     * @param channel the channel in {@code namespace:key} format (e.g. {@code minecraft:brand})
-     * @return the channel identifier object for the provided channel
-     * @throws IllegalArgumentException if the channel format is invalid
-     * @since 1.1.9
-     */
-    public static MinecraftChannelIdentifier createChannelIdentifier(String channel) {
-        try {
-            return MinecraftChannelIdentifier.from(channel);
-        } catch (NoSuchMethodError | IllegalArgumentException e) {
-            if (channel.contains("|")) {
-                return MinecraftChannelIdentifier.create(channel, "");
-            }
-
-            String[] parts = channel.split(":", 2);
-            if (parts.length != 2) {
-                throw new IllegalArgumentException("Invalid channel identifier: " + channel);
-            }
-
-            return MinecraftChannelIdentifier.create(parts[0], parts[1]);
-        }
-    }
-
     static {
-        PLUGIN_CHANNEL = ApolloVelocityPlatform.createChannelIdentifier(ApolloManager.PLUGIN_MESSAGE_CHANNEL);
+        PLUGIN_CHANNEL = MinecraftChannelIdentifier.create("lunar", "apollo");
     }
 
 }

--- a/velocity/src/main/java/com/lunarclient/apollo/metadata/VelocityMetadata.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/metadata/VelocityMetadata.java
@@ -23,37 +23,57 @@
  */
 package com.lunarclient.apollo.metadata;
 
-import com.lunarclient.apollo.stats.metadata.ApolloMetadataManager;
 import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import lombok.Getter;
+import lombok.Builder;
+import lombok.ToString;
 
 /**
- * The Bukkit implementation of {@link ApolloMetadataManager}.
+ * Represents the velocity metadata implementation.
  *
  * @since 1.1.9
  */
-@Getter
-public class BukkitMetadataManager implements ApolloMetadataManager {
+@ToString
+@Builder(toBuilder = true)
+public class VelocityMetadata extends PlatformMetadata {
 
-    private final Set<String> clientBrands = new HashSet<>();
-    private final Map<String, Integer> resourcePackStatuses = new HashMap<>();
+    /**
+     * Tracks client brands sent by the players.
+     *
+     * <p>A {@link Set} of {@link String} client brands.</p>
+     *
+     * @since 1.1.9
+     */
+    private final Set<String> clientBrands;
 
-    @Override
-    public PlatformMetadata extract() {
-        return BukkitMetadata.builder()
-            .clientBrands(new HashSet<>(this.clientBrands))
-            .resourcePackStatuses(new HashMap<>(this.resourcePackStatuses))
-            .build();
-    }
+    /**
+     * Tracks forge mods sent with the forge handshake.
+     *
+     * <p>A {@link Map} of {@link String} mod id
+     * as a key and {@link String} version as value.</p>
+     *
+     * @since 1.1.9
+     */
+    private final Map<String, String> mods;
 
-    @Override
-    public void clear() {
-        this.clientBrands.clear();
-        this.resourcePackStatuses.clear();
-    }
+    /**
+     * Tracks the server IP and port the player used to connect.
+     *
+     * <p>A {@link Set} of {@link String} server addresses in the format: <code>host:port</code></p>
+     *
+     * @since 1.1.9
+     */
+    private final Set<String> serverAddress;
+
+    /**
+     * Tracks the total number of resource pack status events received.
+     *
+     * <p>Represents a {@link Map} of {@link String} status enum name as a key
+     * and {@link Integer} count of how many times that status has been reported.</p>
+     *
+     * @since 1.1.9
+     */
+    private final Map<String, Integer> resourcePackStatuses;
 
 }

--- a/velocity/src/main/java/com/lunarclient/apollo/metadata/VelocityMetadataManager.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/metadata/VelocityMetadataManager.java
@@ -32,20 +32,24 @@ import java.util.Set;
 import lombok.Getter;
 
 /**
- * The Bukkit implementation of {@link ApolloMetadataManager}.
+ * The Velocity implementation of {@link ApolloMetadataManager}.
  *
  * @since 1.1.9
  */
 @Getter
-public class BukkitMetadataManager implements ApolloMetadataManager {
+public class VelocityMetadataManager implements ApolloMetadataManager {
 
     private final Set<String> clientBrands = new HashSet<>();
+    private final Map<String, String> mods = new HashMap<>();
+    private final Set<String> serverAddress = new HashSet<>();
     private final Map<String, Integer> resourcePackStatuses = new HashMap<>();
 
     @Override
     public PlatformMetadata extract() {
-        return BukkitMetadata.builder()
+        return VelocityMetadata.builder()
             .clientBrands(new HashSet<>(this.clientBrands))
+            .mods(new HashMap<>(this.mods))
+            .serverAddress(new HashSet<>(this.serverAddress))
             .resourcePackStatuses(new HashMap<>(this.resourcePackStatuses))
             .build();
     }
@@ -53,6 +57,8 @@ public class BukkitMetadataManager implements ApolloMetadataManager {
     @Override
     public void clear() {
         this.clientBrands.clear();
+        this.mods.clear();
+        this.serverAddress.clear();
         this.resourcePackStatuses.clear();
     }
 

--- a/velocity/src/main/java/com/lunarclient/apollo/util/ByteBufUtil.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/util/ByteBufUtil.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.util;
+
+import com.google.common.io.ByteArrayDataInput;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Represents a util for reading byte buffs.
+ *
+ * @since 1.1.9
+ */
+public final class ByteBufUtil {
+
+    /**
+     * Reads an int from the given input stream.
+     *
+     * @param in in the {@link ByteArrayDataInput} to read from
+     * @return the read int
+     * @throws IllegalArgumentException if the value length is invalid or too large
+     * @since 1.1.9
+     */
+    public static int readVarInt(ByteArrayDataInput in) {
+        int i = 0;
+        int j = 0;
+
+        while (true) {
+            byte b = in.readByte();
+            i |= (b & 0x7F) << j++ * 7;
+
+            if (j > 5) {
+                throw new RuntimeException("VarInt too big");
+            }
+
+            if ((b & 0x80) != 128) {
+                break;
+            }
+        }
+
+        return i;
+    }
+
+    /**
+     * Reads a UTF-8 encoded string from the given input stream.
+     *
+     * @param in the {@link ByteArrayDataInput} to read from
+     * @return the decoded string
+     * @throws IllegalArgumentException if the value length is invalid or too large
+     * @since 1.1.9
+     */
+    public static String readString(ByteArrayDataInput in) {
+        int length = ByteBufUtil.readVarInt(in);
+        byte[] bytes = new byte[length];
+        in.readFully(bytes);
+
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private ByteBufUtil() {
+    }
+
+}


### PR DESCRIPTION
## Overview

**Description:**
Add cross-platform user metadata reporting to the `ServerHeartbeatRequest` request.

**Changes:**
 - Add `user-metadata` config key under the `mcstats` section
 - Update **Velocity-API** version from `3.0.1` to `3.3.0-SNAPSHOT`  


## Tracked Metadata

- **Bukkit & Folia**
  - Client Brands: A set of unique client brands from players.
  - Resource Pack Statuses: A map counting each resource pack status.

- **Bungee**
  - Client Brands: A set of unique client brands from connecting players.
  - Forge Mods: A map of Forge mod IDs to their versions.
  - Server Addresses: A set of unique server addresses (`address:port`) players used to connect.

- **Velocity**
  - Client Brands: A set of unique client brands from players.  
  - Forge Mods: A map of Forge mod IDs to their versions.  
  - Server Addresses: A set of unique virtual hosts (`address:port`) players used to connect.  
  - Resource Pack Statuses: A map counting each resource pack status.  

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
