### PR TITLE
Convert client brands & mods metadata to be a count-based system

### DIFF
--- a/bukkit/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
@@ -94,7 +94,9 @@ public final class ApolloMetadataListener implements Listener {
 
     private void collectBrand(String brand) {
         BukkitMetadataManager manager = (BukkitMetadataManager) ApolloManager.getMetadataManager();
-        manager.getClientBrands().add(brand);
+        Map<String, Integer> brands = manager.getClientBrands();
+
+        brands.put(brand, brands.getOrDefault(brand, 0) + 1);
     }
 
 }

--- a/bukkit/src/main/java/com/lunarclient/apollo/metadata/BukkitMetadata.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/metadata/BukkitMetadata.java
@@ -25,7 +25,6 @@ package com.lunarclient.apollo.metadata;
 
 import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
 import java.util.Map;
-import java.util.Set;
 import lombok.Builder;
 import lombok.ToString;
 
@@ -41,11 +40,12 @@ public class BukkitMetadata extends PlatformMetadata {
     /**
      * Tracks client brands sent by the players.
      *
-     * <p>A {@link Set} of {@link String} client brands.</p>
+     * <p>Represents a {@link Map} of {@link String} client brand as a key
+     * and {@link Integer} count of how many times that brand has been reported.</p>
      *
      * @since 1.1.9
      */
-    private final Set<String> clientBrands;
+    private final Map<String, Integer> clientBrands;
 
     /**
      * Tracks the total number of resource pack status events received.

--- a/bukkit/src/main/java/com/lunarclient/apollo/metadata/BukkitMetadataManager.java
+++ b/bukkit/src/main/java/com/lunarclient/apollo/metadata/BukkitMetadataManager.java
@@ -26,9 +26,7 @@ package com.lunarclient.apollo.metadata;
 import com.lunarclient.apollo.stats.metadata.ApolloMetadataManager;
 import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import lombok.Getter;
 
 /**
@@ -39,13 +37,13 @@ import lombok.Getter;
 @Getter
 public class BukkitMetadataManager implements ApolloMetadataManager {
 
-    private final Set<String> clientBrands = new HashSet<>();
+    private final Map<String, Integer> clientBrands = new HashMap<>();
     private final Map<String, Integer> resourcePackStatuses = new HashMap<>();
 
     @Override
     public PlatformMetadata extract() {
         return BukkitMetadata.builder()
-            .clientBrands(new HashSet<>(this.clientBrands))
+            .clientBrands(new HashMap<>(this.clientBrands))
             .resourcePackStatuses(new HashMap<>(this.resourcePackStatuses))
             .build();
     }

--- a/bungee/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Map;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -129,7 +130,9 @@ public final class ApolloMetadataListener implements Listener {
 
     private void collectBrand(String brand) {
         BungeeMetadataManager manager = (BungeeMetadataManager) ApolloManager.getMetadataManager();
-        manager.getClientBrands().add(brand);
+        Map<String, Integer> brands = manager.getClientBrands();
+
+        brands.put(brand, brands.getOrDefault(brand, 0) + 1);
     }
 
     private void handleFml(byte[] data) {
@@ -142,14 +145,16 @@ public final class ApolloMetadataListener implements Listener {
                 return;
             }
 
-            int count = ByteBufUtil.readVarInt(in);
+            BungeeMetadataManager manager = (BungeeMetadataManager) ApolloManager.getMetadataManager();
+            Map<String, Integer> mods = manager.getMods();
 
+            int count = ByteBufUtil.readVarInt(in);
             for (int i = 0; i < count; i++) {
                 String modId = ByteBufUtil.readString(in);
                 String version = ByteBufUtil.readString(in);
+                String key = modId + ":" + version;
 
-                BungeeMetadataManager manager = (BungeeMetadataManager) ApolloManager.getMetadataManager();
-                manager.getMods().put(modId, version);
+                mods.put(key, mods.getOrDefault(key, 0) + 1);
             }
         } catch (Exception ignored) {
         }

--- a/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadata.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadata.java
@@ -41,21 +41,22 @@ public class BungeeMetadata extends PlatformMetadata {
     /**
      * Tracks client brands sent by the players.
      *
-     * <p>A {@link Set} of {@link String} client brands.</p>
+     * <p>Represents a {@link Map} of {@link String} client brand as a key
+     * and {@link Integer} count of how many times that brand has been reported.</p>
      *
      * @since 1.1.9
      */
-    private final Set<String> clientBrands;
+    private final Map<String, Integer> clientBrands;
 
     /**
      * Tracks forge mods sent with the forge handshake.
      *
-     * <p>A {@link Map} of {@link String} mod id
-     * as a key and {@link String} version as value.</p>
+     * <p>A {@link Map} of {@link String} mod info in the format: <code>id:version</code>
+     * as a key and {@link Integer} count of how many times that mod has been reported.</p>
      *
      * @since 1.1.9
      */
-    private final Map<String, String> mods;
+    private final Map<String, Integer> mods;
 
     /**
      * Tracks the server IP and port the player used to connect.

--- a/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadataManager.java
+++ b/bungee/src/main/java/com/lunarclient/apollo/metadata/BungeeMetadataManager.java
@@ -39,14 +39,14 @@ import lombok.Getter;
 @Getter
 public class BungeeMetadataManager implements ApolloMetadataManager {
 
-    private final Set<String> clientBrands = new HashSet<>();
-    private final Map<String, String> mods = new HashMap<>();
+    private final Map<String, Integer> clientBrands = new HashMap<>();
+    private final Map<String, Integer> mods = new HashMap<>();
     private final Set<String> serverAddress = new HashSet<>();
 
     @Override
     public PlatformMetadata extract() {
         return BungeeMetadata.builder()
-            .clientBrands(new HashSet<>(this.clientBrands))
+            .clientBrands(new HashMap<>(this.clientBrands))
             .mods(new HashMap<>(this.mods))
             .serverAddress(new HashSet<>(this.serverAddress))
             .build();

--- a/folia/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
+++ b/folia/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
@@ -70,7 +70,9 @@ public final class ApolloMetadataListener implements Listener {
             }
 
             FoliaMetadataManager manager = (FoliaMetadataManager) ApolloManager.getMetadataManager();
-            manager.getClientBrands().add(brand);
+            Map<String, Integer> brands = manager.getClientBrands();
+
+            brands.put(brand, brands.getOrDefault(brand, 0) + 1);
         }, 20L * 3);
     }
 

--- a/folia/src/main/java/com/lunarclient/apollo/metadata/FoliaMetadata.java
+++ b/folia/src/main/java/com/lunarclient/apollo/metadata/FoliaMetadata.java
@@ -25,7 +25,6 @@ package com.lunarclient.apollo.metadata;
 
 import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
 import java.util.Map;
-import java.util.Set;
 import lombok.Builder;
 import lombok.ToString;
 
@@ -41,11 +40,12 @@ public class FoliaMetadata extends PlatformMetadata {
     /**
      * Tracks client brands sent by the players.
      *
-     * <p>A {@link Set} of {@link String} client brands.</p>
+     * <p>Represents a {@link Map} of {@link String} client brand as a key
+     * and {@link Integer} count of how many times that brand has been reported.</p>
      *
      * @since 1.1.9
      */
-    private final Set<String> clientBrands;
+    private final Map<String, Integer> clientBrands;
 
     /**
      * Tracks the total number of resource pack status events received.

--- a/folia/src/main/java/com/lunarclient/apollo/metadata/FoliaMetadataManager.java
+++ b/folia/src/main/java/com/lunarclient/apollo/metadata/FoliaMetadataManager.java
@@ -26,9 +26,7 @@ package com.lunarclient.apollo.metadata;
 import com.lunarclient.apollo.stats.metadata.ApolloMetadataManager;
 import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 
@@ -40,13 +38,13 @@ import lombok.Getter;
 @Getter
 public class FoliaMetadataManager implements ApolloMetadataManager {
 
-    private final Set<String> clientBrands = ConcurrentHashMap.newKeySet();
+    private final Map<String, Integer> clientBrands = new ConcurrentHashMap<>();
     private final Map<String, Integer> resourcePackStatuses = new ConcurrentHashMap<>();
 
     @Override
     public PlatformMetadata extract() {
         return FoliaMetadata.builder()
-            .clientBrands(new HashSet<>(this.clientBrands))
+            .clientBrands(new HashMap<>(this.clientBrands))
             .resourcePackStatuses(new HashMap<>(this.resourcePackStatuses))
             .build();
     }

--- a/minestom/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
+++ b/minestom/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
@@ -67,8 +67,11 @@ public final class ApolloMetadataListener {
         }
 
         ByteBuffer buffer = ByteBuffer.wrap(event.getMessage());
+        String brand = ByteBufUtil.readString(buffer);
         MinestomMetadataManager manager = (MinestomMetadataManager) ApolloManager.getMetadataManager();
-        manager.getClientBrands().add(ByteBufUtil.readString(buffer));
+        Map<String, Integer> brands = manager.getClientBrands();
+
+        brands.put(brand, brands.getOrDefault(brand, 0) + 1);
     }
 
 }

--- a/minestom/src/main/java/com/lunarclient/apollo/metadata/MinestomMetadata.java
+++ b/minestom/src/main/java/com/lunarclient/apollo/metadata/MinestomMetadata.java
@@ -25,7 +25,6 @@ package com.lunarclient.apollo.metadata;
 
 import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
 import java.util.Map;
-import java.util.Set;
 import lombok.Builder;
 import lombok.ToString;
 
@@ -41,11 +40,12 @@ public class MinestomMetadata extends PlatformMetadata {
     /**
      * Tracks client brands sent by the players.
      *
-     * <p>A {@link Set} of {@link String} client brands.</p>
+     * <p>Represents a {@link Map} of {@link String} client brand as a key
+     * and {@link Integer} count of how many times that brand has been reported.</p>
      *
      * @since 1.2.0
      */
-    private final Set<String> clientBrands;
+    private final Map<String, Integer> clientBrands;
 
     /**
      * Tracks the total number of resource pack status events received.

--- a/minestom/src/main/java/com/lunarclient/apollo/metadata/MinestomMetadataManager.java
+++ b/minestom/src/main/java/com/lunarclient/apollo/metadata/MinestomMetadataManager.java
@@ -26,9 +26,7 @@ package com.lunarclient.apollo.metadata;
 import com.lunarclient.apollo.stats.metadata.ApolloMetadataManager;
 import com.lunarclient.apollo.stats.metadata.PlatformMetadata;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import lombok.Getter;
 
 /**
@@ -39,13 +37,13 @@ import lombok.Getter;
 @Getter
 public class MinestomMetadataManager implements ApolloMetadataManager {
 
-    private final Set<String> clientBrands = new HashSet<>();
+    private final Map<String, Integer> clientBrands = new HashMap<>();
     private final Map<String, Integer> resourcePackStatuses = new HashMap<>();
 
     @Override
     public PlatformMetadata extract() {
         return MinestomMetadata.builder()
-            .clientBrands(new HashSet<>(this.clientBrands))
+            .clientBrands(new HashMap<>(this.clientBrands))
             .resourcePackStatuses(new HashMap<>(this.resourcePackStatuses))
             .build();
     }

--- a/velocity/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/listener/ApolloMetadataListener.java
@@ -74,8 +74,11 @@ public final class ApolloMetadataListener {
      */
     @Subscribe
     public void onPlayerClientBrand(PlayerClientBrandEvent event) {
+        String brand = event.getBrand();
         VelocityMetadataManager manager = (VelocityMetadataManager) ApolloManager.getMetadataManager();
-        manager.getClientBrands().add(event.getBrand());
+        Map<String, Integer> brands = manager.getClientBrands();
+
+        brands.put(brand, brands.getOrDefault(brand, 0) + 1);
     }
 
     /**
@@ -121,14 +124,16 @@ public final class ApolloMetadataListener {
                 return;
             }
 
-            int count = ByteBufUtil.readVarInt(in);
+            VelocityMetadataManager manager = (VelocityMetadataManager) ApolloManager.getMetadataManager();
+            Map<String, Integer> mods = manager.getMods();
 
+            int count = ByteBufUtil.readVarInt(in);
             for (int i = 0; i < count; i++) {
                 String modId = ByteBufUtil.readString(in);
                 String version = ByteBufUtil.readString(in);
+                String key = modId + ":" + version;
 
-                VelocityMetadataManager manager = (VelocityMetadataManager) ApolloManager.getMetadataManager();
-                manager.getMods().put(modId, version);
+                mods.put(key, mods.getOrDefault(key, 0) + 1);
             }
         } catch (Exception ignored) {
         }

--- a/velocity/src/main/java/com/lunarclient/apollo/metadata/VelocityMetadata.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/metadata/VelocityMetadata.java
@@ -41,21 +41,22 @@ public class VelocityMetadata extends PlatformMetadata {
     /**
      * Tracks client brands sent by the players.
      *
-     * <p>A {@link Set} of {@link String} client brands.</p>
+     * <p>Represents a {@link Map} of {@link String} client brand as a key
+     * and {@link Integer} count of how many times that brand has been reported.</p>
      *
      * @since 1.1.9
      */
-    private final Set<String> clientBrands;
+    private final Map<String, Integer> clientBrands;
 
     /**
      * Tracks forge mods sent with the forge handshake.
      *
-     * <p>A {@link Map} of {@link String} mod id
-     * as a key and {@link String} version as value.</p>
+     * <p>A {@link Map} of {@link String} mod info in the format: <code>id:version</code>
+     * as a key and {@link Integer} count of how many times that mod has been reported.</p>
      *
      * @since 1.1.9
      */
-    private final Map<String, String> mods;
+    private final Map<String, Integer> mods;
 
     /**
      * Tracks the server IP and port the player used to connect.

--- a/velocity/src/main/java/com/lunarclient/apollo/metadata/VelocityMetadataManager.java
+++ b/velocity/src/main/java/com/lunarclient/apollo/metadata/VelocityMetadataManager.java
@@ -39,15 +39,15 @@ import lombok.Getter;
 @Getter
 public class VelocityMetadataManager implements ApolloMetadataManager {
 
-    private final Set<String> clientBrands = new HashSet<>();
-    private final Map<String, String> mods = new HashMap<>();
+    private final Map<String, Integer> clientBrands = new HashMap<>();
+    private final Map<String, Integer> mods = new HashMap<>();
     private final Set<String> serverAddress = new HashSet<>();
     private final Map<String, Integer> resourcePackStatuses = new HashMap<>();
 
     @Override
     public PlatformMetadata extract() {
         return VelocityMetadata.builder()
-            .clientBrands(new HashSet<>(this.clientBrands))
+            .clientBrands(new HashMap<>(this.clientBrands))
             .mods(new HashMap<>(this.mods))
             .serverAddress(new HashSet<>(this.serverAddress))
             .resourcePackStatuses(new HashMap<>(this.resourcePackStatuses))


### PR DESCRIPTION
## Overview

**Description:**
Refactored client brand and mod tracking to count occurrences instead of storing only unique values.

**Changes:**
- Replaced `Set<String>` with `Map<String, Integer>` for client brands across all platforms.
- Replaced `Map<String, String>` with `Map<String, Integer>` for mods in Bungee and Velocity (key format: `id:version`).

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
