### PR TITLE
Lightweight(JSON): Add serverbound & roundtrip packets examples

### DIFF
--- a/docs/developers/lightweight/json/_meta.json
+++ b/docs/developers/lightweight/json/_meta.json
@@ -1,6 +1,8 @@
 {
     "getting-started": "Getting Started",
     "player-detection": "Player Detection",
+    "serverbound-packets": "Serverbound Packets",
+    "roundtrip-packets": "Roundtrip Packets",
     "packet-util": "Packet Util",
     "object-util": "Object Util",
     "adventure-util": "Adventure Util"

--- a/docs/developers/lightweight/json/getting-started.mdx
+++ b/docs/developers/lightweight/json/getting-started.mdx
@@ -18,5 +18,7 @@ While constructing messages, note that the `@type` field isn't required if the m
 🔗 [Detecting players using LunarClient](/apollo/developers/lightweight/json/player-detection)<br/>
 🔗 [Common Apollo Objects](/apollo/developers/lightweight/json/object-util)<br/>
 🔗 [Adventure Util](/apollo/developers/lightweight/json/adventure-util)<br/>
+🔗 [Apollo Serverbound packets](/apollo/developers/lightweight/json/serverbound-packets)<br/>
+🔗 [Apollo Roundtrip packets](/apollo/developers/lightweight/json/roundtrip-packets)<br/>
 
 For examples of module integration, refer to the specific Module pages. Each page contains code samples under the `Manual JSON Object Construction` tab. For instance, you can find sample code for the `BorderModule` on its dedicated page [BorderModule](/apollo/developers/modules/border#sample-code) in the `Sample Code` section.

--- a/docs/developers/lightweight/json/packet-util.mdx
+++ b/docs/developers/lightweight/json/packet-util.mdx
@@ -13,9 +13,9 @@ The methods in this utility leverage the same plugin messaging channel as the Ap
 To utilize Apollo Modules, first define a list of the modules you want to use:
 
 ```java
-private static final List<String> APOLLO_MODULES = Arrays.asList("limb", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
-    "entity", "glow", "hologram", "mod_setting", "nametag", "nick_hider", "notification", "packet_enrichment", "rich_presence",
-    "server_rule", "staff_mod", "stopwatch", "team", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
+private static final List<String> APOLLO_MODULES = Arrays.asList("auto_text_hotkey", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
+    "entity", "glint", "glow", "hologram", "inventory", "limb", "mod_setting", "nametag", "nick_hider", "notification", "pay_now", "packet_enrichment",
+    "rich_presence", "saturation", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
 );
 ```
 
@@ -34,6 +34,11 @@ static {
     // Module Options that the client needs to notified about, these properties are sent with the enable module packet
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
+    CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);
+    CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", false);
+    CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", false);
+    CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item.send-packet", false);
+    CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item-bucket.send-packet", false);
     CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-game", false);
     CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-commands", Arrays.asList("/server", "/servers", "/hub"));
     CONFIG_MODULE_PROPERTIES.put("server_rule", "disable-shaders", false);

--- a/docs/developers/lightweight/json/packet-util.mdx
+++ b/docs/developers/lightweight/json/packet-util.mdx
@@ -31,7 +31,7 @@ Next, specify the properties for these modules. These properties are included in
 private static final Table<String, String, Object> CONFIG_MODULE_PROPERTIES = HashBasedTable.create();
 
 static {
-    // Module Options that the client needs to notified about, these properties are sent with the enable module packet
+    // Module Options the client needs to be notified about. These properties are sent with the enable module packet.
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);

--- a/docs/developers/lightweight/json/roundtrip-packets.mdx
+++ b/docs/developers/lightweight/json/roundtrip-packets.mdx
@@ -1,0 +1,90 @@
+import { Callout } from 'nextra-theme-docs'
+
+# Roundtrip Packets
+
+## Overview
+
+This example demonstrates how to handle roundtrip packets between the server and the Lunar Client using JSON messages. These packets are sent from the server, expecting a corresponding response from the client. The example utilizes a map to track the requests and their corresponding responses.
+
+<Callout type="info">
+    Note that this method uses a different plugin channel for
+    sending and receiving packets, which is `apollo:json`.
+</Callout>
+
+## Integration
+
+```java
+public class ApolloRoundtripJsonListener implements PluginMessageListener {
+
+    private static final String TYPE_PREFIX = "type.googleapis.com/";
+    private static final JsonParser JSON_PARSER = new JsonParser();
+
+    @Getter
+    private static ApolloRoundtripJsonListener instance;
+
+    private final Map<UUID, Map<UUID, CompletableFuture<JsonObject>>> roundTripPacketFutures = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+
+    public ApolloRoundtripJsonListener(ApolloExamplePlugin plugin) {
+        instance = this;
+        Bukkit.getServer().getMessenger().registerIncomingPluginChannel(plugin, "apollo:json", this);
+    }
+
+    @Override
+    public void onPluginMessageReceived(@NonNull String channel, @NonNull Player player, byte[] bytes) {
+        JsonObject payload;
+        try {
+            payload = JSON_PARSER.parse(new String(bytes, StandardCharsets.UTF_8)).getAsJsonObject();
+        } catch (Exception e) {
+            return;
+        }
+
+        if (!payload.has("@type")) {
+            return;
+        }
+
+        String type = payload.get("@type").getAsString();
+        if (type.startsWith(TYPE_PREFIX)) {
+            type = type.substring(TYPE_PREFIX.length());
+        }
+
+        if ("lunarclient.apollo.transfer.v1.PingResponse".equals(type)
+                || "lunarclient.apollo.transfer.v1.TransferResponse".equals(type)) {
+            UUID requestId = UUID.fromString(payload.get("request_id").getAsString().replace("+", "-"));
+            this.handleResponse(player, requestId, payload);
+        }
+    }
+
+    public CompletableFuture<JsonObject> sendRequest(Player player, UUID requestId, JsonObject request, String requestType) {
+        request.addProperty("@type", TYPE_PREFIX + requestType);
+        request.addProperty("request_id", requestId.toString());
+        JsonPacketUtil.sendPacket(player, request);
+
+        CompletableFuture<JsonObject> future = new CompletableFuture<>();
+
+        this.roundTripPacketFutures
+            .computeIfAbsent(player.getUniqueId(), k -> new ConcurrentHashMap<>())
+            .put(requestId, future);
+
+        ScheduledFuture<?> timeoutTask = this.executorService.schedule(() ->
+                future.completeExceptionally(new TimeoutException("Response timed out")),
+            10, TimeUnit.SECONDS
+        );
+
+        future.whenComplete((result, throwable) -> timeoutTask.cancel(false));
+        return future;
+    }
+
+    private void handleResponse(Player player, UUID requestId, JsonObject message) {
+        Map<UUID, CompletableFuture<JsonObject>> futures = this.roundTripPacketFutures.get(player.getUniqueId());
+        if (futures == null) {
+            return;
+        }
+
+        CompletableFuture<JsonObject> future = futures.remove(requestId);
+        if (future != null) {
+            future.complete(message);
+        }
+    }
+}
+```

--- a/docs/developers/lightweight/json/serverbound-packets.mdx
+++ b/docs/developers/lightweight/json/serverbound-packets.mdx
@@ -1,0 +1,144 @@
+import { Callout } from 'nextra-theme-docs'
+
+# Serverbound Packets
+
+## Overview
+
+Players using Lunar Client may send packets to the server for specific Apollo modules, such as the `PacketEnrichment Module` and/or when the player is joining the server. This example demonstrates how to handle packets sent from the client that are related to Apollo while using JSON messages.
+
+Additionally, the `Transfer Module` expects a response packet from the client after the server sends a request. For an example of how to handle roundtrip packets, visit [Packet Roundtrip Example](/apollo/developers/lightweight/json/roundtrip-packets)
+
+<Callout type="info">
+    Note that this method uses a different plugin channel for
+    sending and receiving packets, which is `apollo:json`.
+</Callout>
+
+## Integration
+
+```java
+public class ApolloPacketReceiveJsonListener implements PluginMessageListener {
+
+    private static final String TYPE_PREFIX = "type.googleapis.com/";
+    private static final JsonParser JSON_PARSER = new JsonParser();
+
+    public ApolloPacketReceiveJsonListener(ApolloExamplePlugin plugin) {
+        Bukkit.getServer().getMessenger().registerIncomingPluginChannel(plugin, "apollo:json", this);
+    }
+
+    @Override
+    public void onPluginMessageReceived(@NonNull String channel, @NonNull Player player, byte[] bytes) {
+        JsonObject payload;
+        try {
+            payload = JSON_PARSER.parse(new String(bytes, StandardCharsets.UTF_8)).getAsJsonObject();
+        } catch (Exception e) {
+            return;
+        }
+
+        if (!payload.has("@type")) {
+            return;
+        }
+
+        String type = payload.get("@type").getAsString();
+        if (type.startsWith(TYPE_PREFIX)) {
+            type = type.substring(TYPE_PREFIX.length());
+        }
+
+        if ("lunarclient.apollo.player.v1.PlayerHandshakeMessage".equals(type)) {
+            this.onPlayerHandshake(payload);
+        }
+
+        // Packet Enrichment Module
+        if ("lunarclient.apollo.packetenrichment.v1.PlayerAttackMessage".equals(type)) {
+            this.onPlayerAttack(payload);
+        } else if ("lunarclient.apollo.packetenrichment.v1.PlayerChatOpenMessage".equals(type)) {
+            this.onPlayerChatOpen(payload);
+        } else if ("lunarclient.apollo.packetenrichment.v1.PlayerChatCloseMessage".equals(type)) {
+            this.onPlayerChatClose(payload);
+        } else if ("lunarclient.apollo.packetenrichment.v1.PlayerUseItemMessage".equals(type)) {
+            this.onPlayerUseItem(payload);
+        } else if ("lunarclient.apollo.packetenrichment.v1.PlayerUseItemBucketMessage".equals(type)) {
+            this.onPlayerUseItemBucket(payload);
+        }
+    }
+
+    private void onPlayerHandshake(JsonObject message) {
+        String checkoutSupport = message.get("embedded_checkout_support").getAsString();
+
+        JsonObject minecraftVersion = message.getAsJsonObject("minecraft_version");
+        String version = minecraftVersion.get("enum").getAsString();
+
+        JsonObject lunarClientVersion = message.getAsJsonObject("lunar_client_version");
+        String gitBranch = lunarClientVersion.get("git_branch").getAsString();
+        String gitCommit = lunarClientVersion.get("git_commit").getAsString();
+        String semVer = lunarClientVersion.get("semver").getAsString();
+
+        for (JsonElement element : message.getAsJsonArray("installed_mods")) {
+            JsonObject mod = element.getAsJsonObject();
+
+            String modId = mod.get("id").getAsString();
+            String displayName = mod.get("name").getAsString();
+            String modVersion = mod.get("version").getAsString();
+            String modType = mod.get("type").getAsString();
+        }
+    }
+
+    private void onPlayerAttack(JsonObject message) {
+        long instantiationTimeMs = JsonUtil.toJavaTimestamp(message);
+
+        JsonObject targetInfo = message.getAsJsonObject("target_info");
+        JsonObject attackerInfo = message.getAsJsonObject("attacker_info");
+
+        this.onPlayerInfo(targetInfo);
+        this.onPlayerInfo(attackerInfo);
+    }
+
+    private void onPlayerChatOpen(JsonObject message) {
+        long instantiationTimeMs = JsonUtil.toJavaTimestamp(message);
+        this.onPlayerInfo(message.getAsJsonObject("player_info"));
+    }
+
+    private void onPlayerChatClose(JsonObject message) {
+        long instantiationTimeMs = JsonUtil.toJavaTimestamp(message);
+        this.onPlayerInfo(message.getAsJsonObject("player_info"));
+    }
+
+    private void onPlayerUseItem(JsonObject message) {
+        long instantiationTimeMs = JsonUtil.toJavaTimestamp(message);
+        this.onPlayerInfo(message.getAsJsonObject("player_info"));
+
+        boolean mainHand = message.get("main_hand").getAsBoolean();
+    }
+
+    private void onPlayerUseItemBucket(JsonObject message) {
+        long instantiationTimeMs = JsonUtil.toJavaTimestamp(message);
+        this.onPlayerInfo(message.getAsJsonObject("player_info"));
+
+        JsonObject rayTraceResult = message.getAsJsonObject("ray_trace_result");
+
+        if (rayTraceResult.has("block")) {
+            JsonObject blockHit = rayTraceResult.getAsJsonObject("block");
+
+            JsonObject hitLocation = blockHit.getAsJsonObject("hit_location");
+            JsonObject blockLocation = blockHit.getAsJsonObject("block_location");
+            String directionStr = blockHit.get("direction").getAsString();
+        } else if (rayTraceResult.has("entity")) {
+            JsonObject entityHit = rayTraceResult.getAsJsonObject("entity");
+
+            JsonObject hitLocation = entityHit.getAsJsonObject("hit_location");
+            String entityId = entityHit.get("entity_id").getAsString();
+        } else {
+            // MISS
+        }
+    }
+
+    private void onPlayerInfo(JsonObject info) {
+        UUID uuid = JsonUtil.toJavaUuid(info.getAsJsonObject("player_uuid"));
+        Location location = JsonUtil.toBukkitPlayerLocation(info.getAsJsonObject("location"));
+        boolean sneaking = info.get("sneaking").getAsBoolean();
+        boolean sprinting = info.get("sprinting").getAsBoolean();
+        boolean jumping = info.get("jumping").getAsBoolean();
+        float forwardSpeed = info.get("forward_speed").getAsFloat();
+        float strafeSpeed = info.get("strafe_speed").getAsFloat();
+    }
+}
+```

--- a/docs/developers/lightweight/protobuf/object-util.mdx
+++ b/docs/developers/lightweight/protobuf/object-util.mdx
@@ -7,12 +7,16 @@ These utilities facilitate the creation of Apollo objects, commonly used across 
 ## Integration
 
 ```java
-public static UUID toJavaUuid(Uuid message) {
-    return new UUID(message.getHigh64(), message.getLow64());
+public static UUID toJavaUuid(JsonObject obj) {
+    long high = Long.parseUnsignedLong(obj.get("high64").getAsString());
+    long low = Long.parseUnsignedLong(obj.get("low64").getAsString());
+    return new UUID(high, low);
 }
 
-public static long toJavaTimestamp(Timestamp message) {
-    return message.getSeconds() * 1000 + message.getNanos() / 1000000;
+public static long toJavaTimestamp(JsonObject timestampObject) {
+    JsonObject packetInfo = timestampObject.getAsJsonObject("packet_info");
+    String iso = packetInfo.get("instantiation_time").getAsString();
+    return Instant.parse(iso).toEpochMilli();
 }
 
 public static Uuid createUuidProto(UUID object) {
@@ -73,14 +77,19 @@ public static BlockLocation createBlockLocationProto(Location location) {
         .build();
 }
 
-public static Location toBukkitLocation(com.lunarclient.apollo.common.v1.Location message) {
-    return new Location(Bukkit.getWorld(message.getWorld()), message.getX(), message.getY(), message.getZ());
+public static Location toBukkitLocation(JsonObject message) {
+    return new Location(
+        Bukkit.getWorld(message.get("world").getAsString()),
+        message.get("x").getAsDouble(),
+        message.get("y").getAsDouble(),
+        message.get("z").getAsDouble()
+    );
 }
 
-public static Location toBukkitLocation(com.lunarclient.apollo.common.v1.PlayerLocation message) {
-    Location location = ProtobufUtil.toBukkitLocation(message.getLocation());
-    location.setYaw(message.getYaw());
-    location.setPitch(message.getPitch());
+public static Location toBukkitPlayerLocation(JsonObject message) {
+    Location location = JsonUtil.toBukkitLocation(message.getAsJsonObject("location"));
+    location.setYaw(message.get("yaw").getAsFloat());
+    location.setPitch(message.get("pitch").getAsFloat());
     return location;
 }
 ```

--- a/docs/developers/lightweight/protobuf/packet-util.mdx
+++ b/docs/developers/lightweight/protobuf/packet-util.mdx
@@ -31,7 +31,7 @@ Next, specify the properties for these modules. These properties are included in
 private static final Table<String, String, Value> CONFIG_MODULE_PROPERTIES = HashBasedTable.create();
 
 static {
-    // Module Options that the client needs to notified about, these properties are sent with the enable module packet
+    // Module Options the client needs to be notified about. These properties are sent with the enable module packet.
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());

--- a/docs/developers/lightweight/protobuf/packet-util.mdx
+++ b/docs/developers/lightweight/protobuf/packet-util.mdx
@@ -13,9 +13,9 @@ The methods in this utility leverage the same plugin messaging channel as the Ap
 To utilize Apollo Modules, first define a list of the modules you want to use:
 
 ```java
-private static final List<String> APOLLO_MODULES = Arrays.asList("limb", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
-    "entity", "glow", "hologram", "mod_setting", "nametag", "nick_hider", "notification", "packet_enrichment", "rich_presence",
-    "server_rule", "staff_mod", "stopwatch", "team", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
+private static final List<String> APOLLO_MODULES = Arrays.asList("auto_text_hotkey", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
+    "entity", "glint", "glow", "hologram", "inventory", "limb", "mod_setting", "nametag", "nick_hider", "notification", "pay_now", "packet_enrichment",
+    "rich_presence", "saturation", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
 );
 ```
 
@@ -31,7 +31,14 @@ Next, specify the properties for these modules. These properties are included in
 private static final Table<String, String, Value> CONFIG_MODULE_PROPERTIES = HashBasedTable.create();
 
 static {
+    // Module Options that the client needs to notified about, these properties are sent with the enable module packet
+    // While using the Apollo plugin this would be equivalent to modifying the config.yml
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
+    CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());
+    CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", Value.newBuilder().setBoolValue(false).build());
+    CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", Value.newBuilder().setBoolValue(false).build());
+    CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item.send-packet", Value.newBuilder().setBoolValue(false).build());
+    CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item-bucket.send-packet", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-game", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-commands", Value.newBuilder().setListValue(
         ListValue.newBuilder().addAllValues(Arrays.asList(

--- a/docs/developers/lightweight/protobuf/roundtrip-packets.mdx
+++ b/docs/developers/lightweight/protobuf/roundtrip-packets.mdx
@@ -21,7 +21,7 @@ public class ApolloRoundtripProtoListener implements PluginMessageListener {
     }
 
     @Override
-    public void onPluginMessageReceived(String s, Player player, byte[] bytes) {
+    public void onPluginMessageReceived(@NonNull String channel, @NonNull Player player, byte[] bytes) {
         try {
             Any any = Any.parseFrom(bytes);
 

--- a/docs/developers/lightweight/protobuf/serverbound-packets.mdx
+++ b/docs/developers/lightweight/protobuf/serverbound-packets.mdx
@@ -16,7 +16,7 @@ public class ApolloPacketReceiveProtoListener implements PluginMessageListener {
     }
 
     @Override
-    public void onPluginMessageReceived(String s, Player player, byte[] bytes) {
+    public void onPluginMessageReceived(@NonNull String channel, @NonNull Player player, byte[] bytes) {
         try {
             Any any = Any.parseFrom(bytes);
 
@@ -33,6 +33,8 @@ public class ApolloPacketReceiveProtoListener implements PluginMessageListener {
                 this.onPlayerChatClose(any.unpack(PlayerChatCloseMessage.class));
             } else if (any.is(PlayerUseItemMessage.class)) {
                 this.onPlayerUseItem(any.unpack(PlayerUseItemMessage.class));
+            } else if (any.is(PlayerUseItemBucketMessage.class)) {
+                this.onPlayerUseItemBucket(any.unpack(PlayerUseItemBucketMessage.class));
             }
         } catch (InvalidProtocolBufferException e) {
             throw new RuntimeException(e);
@@ -40,6 +42,7 @@ public class ApolloPacketReceiveProtoListener implements PluginMessageListener {
     }
 
     private void onPlayerHandshake(PlayerHandshakeMessage message) {
+        EmbeddedCheckoutSupport checkoutSupport = message.getEmbeddedCheckoutSupport();
         MinecraftVersion minecraftVersion = message.getMinecraftVersion();
 
         LunarClientVersion lunarClientVersion = message.getLunarClientVersion();
@@ -89,9 +92,32 @@ public class ApolloPacketReceiveProtoListener implements PluginMessageListener {
         boolean mainHand = message.getMainHand();
     }
 
+    private void onPlayerUseItemBucket(PlayerUseItemBucketMessage message) {
+        long instantiationTimeMs = ProtobufUtil.toJavaTimestamp(message.getPacketInfo().getInstantiationTime());
+
+        PlayerInfo playerInfo = message.getPlayerInfo();
+        this.onPlayerInfo(playerInfo);
+
+        RayTraceResult rayTraceResult = message.getRayTraceResult();
+
+        if (rayTraceResult.hasBlock()) {
+            BlockHit blockHit = rayTraceResult.getBlock();
+
+            Location hitLocation = blockHit.getHitLocation();
+            BlockLocation blockLocation = blockHit.getBlockLocation();
+            Direction direction = blockHit.getDirection();
+        } else if (rayTraceResult.hasEntity()) {
+            EntityHit entityHit = rayTraceResult.getEntity();
+            Location hitLocation = entityHit.getHitLocation();
+            EntityId entityId = entityHit.getEntityId();
+        } else {
+            // Miss
+        }
+    }
+
     private void onPlayerInfo(PlayerInfo info) {
         UUID uuid = ProtobufUtil.toJavaUuid(info.getPlayerUuid());
-        Location location = ProtobufUtil.toBukkitLocation(info.getLocation());
+        org.bukkit.Location location = ProtobufUtil.toBukkitLocation(info.getLocation());
         boolean sneaking = info.getSneaking();
         boolean sprinting = info.getSprinting();
         boolean jumping = info.getJumping();

--- a/docs/developers/modules/transfer.mdx
+++ b/docs/developers/modules/transfer.mdx
@@ -246,15 +246,38 @@ public void pingExample(Player player) {
 
 <Tab>
 
-<Callout type="warning" emoji="⚠️">
-  This example is not implemented.
-</Callout>
-
 **Transfer Player**
 
 ```java
 public void transferExample(Player player) {
+    UUID requestId = UUID.randomUUID();
 
+    JsonObject transferRequestMessage = new JsonObject();
+    transferRequestMessage.addProperty("server_ip", "mc.hypixel.net");
+
+    ApolloRoundtripJsonListener.getInstance()
+        .sendRequest(player, requestId, transferRequestMessage, "lunarclient.apollo.transfer.v1.TransferRequest")
+        .thenAccept(response -> {
+            String message = "";
+            String status = response.get("status").getAsString();
+
+            switch (status) {
+                case "STATUS_ACCEPTED": {
+                    message = "Transfer accepted! Goodbye!";
+                    break;
+                }
+
+                case "STATUS_REJECTED": {
+                    message = "Transfer rejected by client!";
+                    break;
+                }
+            }
+
+            player.sendMessage(message);
+        }).exceptionally(throwable -> {
+            player.sendMessage("Failed to receive a response in time.");
+            return null;
+        });
 }
 ```
 
@@ -262,7 +285,43 @@ public void transferExample(Player player) {
 
 ```java
 public void pingExample(Player player) {
+    UUID requestId = UUID.randomUUID();
 
+    JsonObject pingRequestMessage = new JsonObject();
+    JsonArray serverIps = Lists.newArrayList("mc.hypixel.net", "minehut.com")
+        .stream().collect(JsonArray::new, JsonArray::add, JsonArray::addAll);
+    pingRequestMessage.add("server_ips", serverIps);
+
+    ApolloRoundtripJsonListener.getInstance()
+        .sendRequest(player, requestId, pingRequestMessage, "lunarclient.apollo.transfer.v1.PingRequest")
+        .thenAccept(response -> {
+            JsonArray pingDataList = response.getAsJsonArray("ping_data");
+
+            for (JsonElement element : pingDataList) {
+                JsonObject pingData = element.getAsJsonObject();
+                String message = "";
+
+                String status = pingData.get("status").getAsString();
+                switch (status) {
+                    // Displays successful ping request to display the server IP and the players ping to that server.
+                    case "STATUS_SUCCESS": {
+                        message = String.format("Ping to %s is %d ms.", pingData.get("server_ip").getAsString(), pingData.get("ping").getAsInt());
+                        break;
+                    }
+
+                    // If the ping request times-out
+                    case "STATUS_TIMED_OUT": {
+                        message = String.format("Failed to ping %s", pingData.get("server_ip").getAsString());
+                        break;
+                    }
+                }
+
+                player.sendMessage(message);
+            }
+        }).exceptionally(throwable -> {
+            player.sendMessage("Failed to receive a response in time.");
+            return null;
+        });
 }
 ```
 

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/listener/ApolloPacketReceiveJsonListener.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/listener/ApolloPacketReceiveJsonListener.java
@@ -1,0 +1,162 @@
+/*
+ * This file is part of Apollo, licensed under the MIT License.
+ *
+ * Copyright (c) 2023 Moonsworth
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.lunarclient.apollo.example.json.listener;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.lunarclient.apollo.example.ApolloExamplePlugin;
+import com.lunarclient.apollo.example.json.util.JsonUtil;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jspecify.annotations.NonNull;
+
+public class ApolloPacketReceiveJsonListener implements PluginMessageListener {
+
+    private static final String TYPE_PREFIX = "type.googleapis.com/";
+    private static final JsonParser JSON_PARSER = new JsonParser();
+
+    public ApolloPacketReceiveJsonListener(ApolloExamplePlugin plugin) {
+    }
+
+    @Override
+    public void onPluginMessageReceived(@NonNull String channel, @NonNull Player player, byte[] bytes) {
+        JsonObject payload;
+        try {
+            payload = JSON_PARSER.parse(new String(bytes, StandardCharsets.UTF_8)).getAsJsonObject();
+        } catch (Exception e) {
+            return;
+        }
+
+        if (!payload.has("@type")) {
+            return;
+        }
+
+        String type = payload.get("@type").getAsString();
+        if (type.startsWith(TYPE_PREFIX)) {
+            type = type.substring(TYPE_PREFIX.length());
+        }
+
+        if ("lunarclient.apollo.player.v1.PlayerHandshakeMessage".equals(type)) {
+            this.onPlayerHandshake(payload);
+        }
+
+        // Packet Enrichment Module
+        if ("lunarclient.apollo.packetenrichment.v1.PlayerAttackMessage".equals(type)) {
+            this.onPlayerAttack(payload);
+        } else if ("lunarclient.apollo.packetenrichment.v1.PlayerChatOpenMessage".equals(type)) {
+            this.onPlayerChatOpen(payload);
+        } else if ("lunarclient.apollo.packetenrichment.v1.PlayerChatCloseMessage".equals(type)) {
+            this.onPlayerChatClose(payload);
+        } else if ("lunarclient.apollo.packetenrichment.v1.PlayerUseItemMessage".equals(type)) {
+            this.onPlayerUseItem(payload);
+        } else if ("lunarclient.apollo.packetenrichment.v1.PlayerUseItemBucketMessage".equals(type)) {
+            this.onPlayerUseItemBucket(payload);
+        }
+    }
+
+    private void onPlayerHandshake(JsonObject message) {
+        String checkoutSupport = message.get("embedded_checkout_support").getAsString();
+
+        JsonObject minecraftVersion = message.getAsJsonObject("minecraft_version");
+        String version = minecraftVersion.get("enum").getAsString();
+
+        JsonObject lunarClientVersion = message.getAsJsonObject("lunar_client_version");
+        String gitBranch = lunarClientVersion.get("git_branch").getAsString();
+        String gitCommit = lunarClientVersion.get("git_commit").getAsString();
+        String semVer = lunarClientVersion.get("semver").getAsString();
+
+        for (JsonElement element : message.getAsJsonArray("installed_mods")) {
+            JsonObject mod = element.getAsJsonObject();
+
+            String modId = mod.get("id").getAsString();
+            String displayName = mod.get("name").getAsString();
+            String modVersion = mod.get("version").getAsString();
+            String modType = mod.get("type").getAsString();
+        }
+    }
+
+    private void onPlayerAttack(JsonObject message) {
+        long instantiationTimeMs = JsonUtil.toJavaTimestamp(message);
+
+        JsonObject targetInfo = message.getAsJsonObject("target_info");
+        JsonObject attackerInfo = message.getAsJsonObject("attacker_info");
+
+        this.onPlayerInfo(targetInfo);
+        this.onPlayerInfo(attackerInfo);
+    }
+
+    private void onPlayerChatOpen(JsonObject message) {
+        long instantiationTimeMs = JsonUtil.toJavaTimestamp(message);
+        this.onPlayerInfo(message.getAsJsonObject("player_info"));
+    }
+
+    private void onPlayerChatClose(JsonObject message) {
+        long instantiationTimeMs = JsonUtil.toJavaTimestamp(message);
+        this.onPlayerInfo(message.getAsJsonObject("player_info"));
+    }
+
+    private void onPlayerUseItem(JsonObject message) {
+        long instantiationTimeMs = JsonUtil.toJavaTimestamp(message);
+        this.onPlayerInfo(message.getAsJsonObject("player_info"));
+
+        boolean mainHand = message.get("main_hand").getAsBoolean();
+    }
+
+    private void onPlayerUseItemBucket(JsonObject message) {
+        long instantiationTimeMs = JsonUtil.toJavaTimestamp(message);
+        this.onPlayerInfo(message.getAsJsonObject("player_info"));
+
+        JsonObject rayTraceResult = message.getAsJsonObject("ray_trace_result");
+
+        if (rayTraceResult.has("block")) {
+            JsonObject blockHit = rayTraceResult.getAsJsonObject("block");
+
+            JsonObject hitLocation = blockHit.getAsJsonObject("hit_location");
+            JsonObject blockLocation = blockHit.getAsJsonObject("block_location");
+            String directionStr = blockHit.get("direction").getAsString();
+        } else if (rayTraceResult.has("entity")) {
+            JsonObject entityHit = rayTraceResult.getAsJsonObject("entity");
+
+            JsonObject hitLocation = entityHit.getAsJsonObject("hit_location");
+            String entityId = entityHit.get("entity_id").getAsString();
+        } else {
+            // MISS
+        }
+    }
+
+    private void onPlayerInfo(JsonObject info) {
+        UUID uuid = JsonUtil.toJavaUuid(info.getAsJsonObject("player_uuid"));
+        Location location = JsonUtil.toBukkitPlayerLocation(info.getAsJsonObject("location"));
+        boolean sneaking = info.get("sneaking").getAsBoolean();
+        boolean sprinting = info.get("sprinting").getAsBoolean();
+        boolean jumping = info.get("jumping").getAsBoolean();
+        float forwardSpeed = info.get("forward_speed").getAsFloat();
+        float strafeSpeed = info.get("strafe_speed").getAsFloat();
+    }
+
+}

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/listener/ApolloPlayerJsonListener.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/listener/ApolloPlayerJsonListener.java
@@ -49,7 +49,8 @@ public class ApolloPlayerJsonListener implements Listener {
 
         Messenger messenger = Bukkit.getServer().getMessenger();
         messenger.registerIncomingPluginChannel(plugin, "lunar:apollo", (s, player, bytes) -> { });
-        messenger.registerIncomingPluginChannel(plugin, "apollo:json", (s, player, bytes) -> { });
+        messenger.registerIncomingPluginChannel(plugin, "apollo:json", new ApolloRoundtripJsonListener(plugin));
+        messenger.registerIncomingPluginChannel(plugin, "apollo:json", new ApolloPacketReceiveJsonListener(plugin));
         messenger.registerOutgoingPluginChannel(plugin, "apollo:json");
 
         Bukkit.getPluginManager().registerEvents(this, plugin);

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/listener/ApolloRoundtripJsonListener.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/listener/ApolloRoundtripJsonListener.java
@@ -21,15 +21,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.lunarclient.apollo.example.proto.listener;
+package com.lunarclient.apollo.example.json.listener;
 
-import com.google.protobuf.Any;
-import com.google.protobuf.GeneratedMessageV3;
-import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.lunarclient.apollo.example.ApolloExamplePlugin;
-import com.lunarclient.apollo.example.proto.util.ProtobufPacketUtil;
-import com.lunarclient.apollo.transfer.v1.PingResponse;
-import com.lunarclient.apollo.transfer.v1.TransferResponse;
+import com.lunarclient.apollo.example.json.util.JsonPacketUtil;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -44,48 +42,56 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 import org.jspecify.annotations.NonNull;
 
-public class ApolloRoundtripProtoListener implements PluginMessageListener {
+public class ApolloRoundtripJsonListener implements PluginMessageListener {
+
+    private static final String TYPE_PREFIX = "type.googleapis.com/";
+    private static final JsonParser JSON_PARSER = new JsonParser();
 
     @Getter
-    private static ApolloRoundtripProtoListener instance;
+    private static ApolloRoundtripJsonListener instance;
 
-    private final Map<UUID, Map<UUID, CompletableFuture<GeneratedMessageV3>>> roundTripPacketFutures = new ConcurrentHashMap<>();
+    private final Map<UUID, Map<UUID, CompletableFuture<JsonObject>>> roundTripPacketFutures = new ConcurrentHashMap<>();
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
 
-    public ApolloRoundtripProtoListener(ApolloExamplePlugin plugin) {
+    public ApolloRoundtripJsonListener(ApolloExamplePlugin plugin) {
         instance = this;
     }
 
     @Override
     public void onPluginMessageReceived(@NonNull String channel, @NonNull Player player, byte[] bytes) {
+        JsonObject payload;
         try {
-            Any any = Any.parseFrom(bytes);
+            payload = JSON_PARSER.parse(new String(bytes, StandardCharsets.UTF_8)).getAsJsonObject();
+        } catch (Exception e) {
+            return;
+        }
 
-            if (any.is(PingResponse.class)) {
-                PingResponse message = any.unpack(PingResponse.class);
-                UUID requestId = UUID.fromString(message.getRequestId().toStringUtf8());
-                this.handleResponse(player, requestId, message);
-            } else if (any.is(TransferResponse.class)) {
-                TransferResponse message = any.unpack(TransferResponse.class);
-                UUID requestId = UUID.fromString(message.getRequestId().toStringUtf8());
-                this.handleResponse(player, requestId, message);
-            }
+        if (!payload.has("@type")) {
+            return;
+        }
 
-        } catch (InvalidProtocolBufferException e) {
-            throw new RuntimeException(e);
+        String type = payload.get("@type").getAsString();
+        if (type.startsWith(TYPE_PREFIX)) {
+            type = type.substring(TYPE_PREFIX.length());
+        }
+
+        if ("lunarclient.apollo.transfer.v1.PingResponse".equals(type)
+                || "lunarclient.apollo.transfer.v1.TransferResponse".equals(type)) {
+            UUID requestId = UUID.fromString(payload.get("request_id").getAsString().replace("+", "-"));
+            this.handleResponse(player, requestId, payload);
         }
     }
 
-    public <T extends GeneratedMessageV3> CompletableFuture<T> sendRequest(Player player, UUID requestId,
-                                                                           GeneratedMessageV3 request,
-                                                                           Class<T> responseType) {
-        ProtobufPacketUtil.sendPacket(player, request);
+    public CompletableFuture<JsonObject> sendRequest(Player player, UUID requestId, JsonObject request, String requestType) {
+        request.addProperty("@type", TYPE_PREFIX + requestType);
+        request.addProperty("request_id", requestId.toString());
+        JsonPacketUtil.sendPacket(player, request);
 
-        CompletableFuture<T> future = new CompletableFuture<>();
+        CompletableFuture<JsonObject> future = new CompletableFuture<>();
 
         this.roundTripPacketFutures
             .computeIfAbsent(player.getUniqueId(), k -> new ConcurrentHashMap<>())
-            .put(requestId, (CompletableFuture<GeneratedMessageV3>) future);
+            .put(requestId, future);
 
         ScheduledFuture<?> timeoutTask = this.executorService.schedule(() ->
                 future.completeExceptionally(new TimeoutException("Response timed out")),
@@ -96,13 +102,13 @@ public class ApolloRoundtripProtoListener implements PluginMessageListener {
         return future;
     }
 
-    private <T extends GeneratedMessageV3> void handleResponse(Player player, UUID requestId, T message) {
-        Map<UUID, CompletableFuture<GeneratedMessageV3>> futures = this.roundTripPacketFutures.get(player.getUniqueId());
+    private void handleResponse(Player player, UUID requestId, JsonObject message) {
+        Map<UUID, CompletableFuture<JsonObject>> futures = this.roundTripPacketFutures.get(player.getUniqueId());
         if (futures == null) {
             return;
         }
 
-        CompletableFuture<GeneratedMessageV3> future = futures.remove(requestId);
+        CompletableFuture<JsonObject> future = futures.remove(requestId);
         if (future != null) {
             future.complete(message);
         }

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/module/TransferJsonExample.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/module/TransferJsonExample.java
@@ -23,19 +23,88 @@
  */
 package com.lunarclient.apollo.example.json.module;
 
+import com.google.common.collect.Lists;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.lunarclient.apollo.example.json.listener.ApolloRoundtripJsonListener;
 import com.lunarclient.apollo.example.module.impl.TransferExample;
+import java.util.UUID;
 import org.bukkit.entity.Player;
 
 public class TransferJsonExample extends TransferExample {
 
     @Override
     public void transferExample(Player player) {
-        this.sendNotImplemented(player);
+        UUID requestId = UUID.randomUUID();
+
+        JsonObject transferRequestMessage = new JsonObject();
+        transferRequestMessage.addProperty("server_ip", "mc.hypixel.net");
+
+        ApolloRoundtripJsonListener.getInstance()
+            .sendRequest(player, requestId, transferRequestMessage, "lunarclient.apollo.transfer.v1.TransferRequest")
+            .thenAccept(response -> {
+                String message = "";
+                String status = response.get("status").getAsString();
+
+                switch (status) {
+                    case "STATUS_ACCEPTED": {
+                        message = "Transfer accepted! Goodbye!";
+                        break;
+                    }
+
+                    case "STATUS_REJECTED": {
+                        message = "Transfer rejected by client!";
+                        break;
+                    }
+                }
+
+                player.sendMessage(message);
+            }).exceptionally(throwable -> {
+                player.sendMessage("Failed to receive a response in time.");
+                return null;
+            });
     }
 
     @Override
     public void pingExample(Player player) {
-        this.sendNotImplemented(player);
+        UUID requestId = UUID.randomUUID();
+
+        JsonObject pingRequestMessage = new JsonObject();
+        JsonArray serverIps = Lists.newArrayList("mc.hypixel.net", "minehut.com")
+            .stream().collect(JsonArray::new, JsonArray::add, JsonArray::addAll);
+        pingRequestMessage.add("server_ips", serverIps);
+
+        ApolloRoundtripJsonListener.getInstance()
+            .sendRequest(player, requestId, pingRequestMessage, "lunarclient.apollo.transfer.v1.PingRequest")
+            .thenAccept(response -> {
+                JsonArray pingDataList = response.getAsJsonArray("ping_data");
+
+                for (JsonElement element : pingDataList) {
+                    JsonObject pingData = element.getAsJsonObject();
+                    String message = "";
+
+                    String status = pingData.get("status").getAsString();
+                    switch (status) {
+                        // Displays successful ping request to display the server IP and the players ping to that server.
+                        case "STATUS_SUCCESS": {
+                            message = String.format("Ping to %s is %d ms.", pingData.get("server_ip").getAsString(), pingData.get("ping").getAsInt());
+                            break;
+                        }
+
+                        // If the ping request times-out
+                        case "STATUS_TIMED_OUT": {
+                            message = String.format("Failed to ping %s", pingData.get("server_ip").getAsString());
+                            break;
+                        }
+                    }
+
+                    player.sendMessage(message);
+                }
+            }).exceptionally(throwable -> {
+                player.sendMessage("Failed to receive a response in time.");
+                return null;
+            });
     }
 
 }

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
@@ -49,7 +49,7 @@ public final class JsonPacketUtil {
     private static final Table<String, String, Object> CONFIG_MODULE_PROPERTIES = HashBasedTable.create();
 
     static {
-        // Module Options that the client needs to notified about, these properties are sent with the enable module packet
+        // Module Options the client needs to be notified about. These properties are sent with the enable module packet.
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
@@ -40,9 +40,9 @@ import org.jetbrains.annotations.NotNull;
 
 public final class JsonPacketUtil {
 
-    private static final List<String> APOLLO_MODULES = Arrays.asList("limb", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
-        "entity", "glow", "hologram", "mod_setting", "nametag", "nick_hider", "notification", "packet_enrichment", "rich_presence",
-        "server_rule", "staff_mod", "stopwatch", "team", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
+    private static final List<String> APOLLO_MODULES = Arrays.asList("auto_text_hotkey", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
+        "entity", "glint", "glow", "hologram", "inventory", "limb", "mod_setting", "nametag", "nick_hider", "notification", "pay_now", "packet_enrichment",
+        "rich_presence", "saturation", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
     );
 
     // Module Id -> Option key -> Object
@@ -52,6 +52,11 @@ public final class JsonPacketUtil {
         // Module Options that the client needs to notified about, these properties are sent with the enable module packet
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
+        CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);
+        CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", false);
+        CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", false);
+        CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item.send-packet", false);
+        CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item-bucket.send-packet", false);
         CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-game", false);
         CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-commands", Arrays.asList("/server", "/servers", "/hub"));
         CONFIG_MODULE_PROPERTIES.put("server_rule", "disable-shaders", false);

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonUtil.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonUtil.java
@@ -26,14 +26,28 @@ package com.lunarclient.apollo.example.json.util;
 import com.google.gson.JsonObject;
 import java.awt.Color;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class JsonUtil {
+
+    public static UUID toJavaUuid(JsonObject obj) {
+        long high = Long.parseUnsignedLong(obj.get("high64").getAsString());
+        long low = Long.parseUnsignedLong(obj.get("low64").getAsString());
+        return new UUID(high, low);
+    }
+
+    public static long toJavaTimestamp(JsonObject timestampObject) {
+        JsonObject packetInfo = timestampObject.getAsJsonObject("packet_info");
+        String iso = packetInfo.get("instantiation_time").getAsString();
+        return Instant.parse(iso).toEpochMilli();
+    }
 
     public static JsonObject createEnableModuleObjectWithType(@NotNull String module, Map<String, Object> properties) {
         JsonObject enableModuleObject = JsonPacketUtil.createEnableModuleObject(module, properties);
@@ -103,6 +117,22 @@ public final class JsonUtil {
         locationObject.addProperty("y", location.getBlockY());
         locationObject.addProperty("z", location.getBlockZ());
         return locationObject;
+    }
+
+    public static Location toBukkitLocation(JsonObject message) {
+        return new Location(
+            Bukkit.getWorld(message.get("world").getAsString()),
+            message.get("x").getAsDouble(),
+            message.get("y").getAsDouble(),
+            message.get("z").getAsDouble()
+        );
+    }
+
+    public static Location toBukkitPlayerLocation(JsonObject message) {
+        Location location = JsonUtil.toBukkitLocation(message.getAsJsonObject("location"));
+        location.setYaw(message.get("yaw").getAsFloat());
+        location.setPitch(message.get("pitch").getAsFloat());
+        return location;
     }
 
     public static JsonObject createItemStackIconObject(@Nullable String itemName, int itemId, int customModelData) {

--- a/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/listener/ApolloPacketReceiveProtoListener.java
+++ b/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/listener/ApolloPacketReceiveProtoListener.java
@@ -25,23 +25,31 @@ package com.lunarclient.apollo.example.proto.listener;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.lunarclient.apollo.common.v1.BlockLocation;
+import com.lunarclient.apollo.common.v1.EntityId;
+import com.lunarclient.apollo.common.v1.Location;
 import com.lunarclient.apollo.common.v1.LunarClientVersion;
 import com.lunarclient.apollo.common.v1.MinecraftVersion;
 import com.lunarclient.apollo.example.ApolloExamplePlugin;
 import com.lunarclient.apollo.example.proto.util.ProtobufUtil;
+import com.lunarclient.apollo.packetenrichment.v1.BlockHit;
+import com.lunarclient.apollo.packetenrichment.v1.Direction;
+import com.lunarclient.apollo.packetenrichment.v1.EntityHit;
 import com.lunarclient.apollo.packetenrichment.v1.PlayerAttackMessage;
 import com.lunarclient.apollo.packetenrichment.v1.PlayerChatCloseMessage;
 import com.lunarclient.apollo.packetenrichment.v1.PlayerChatOpenMessage;
 import com.lunarclient.apollo.packetenrichment.v1.PlayerInfo;
+import com.lunarclient.apollo.packetenrichment.v1.PlayerUseItemBucketMessage;
 import com.lunarclient.apollo.packetenrichment.v1.PlayerUseItemMessage;
+import com.lunarclient.apollo.packetenrichment.v1.RayTraceResult;
 import com.lunarclient.apollo.player.v1.EmbeddedCheckoutSupport;
 import com.lunarclient.apollo.player.v1.ModMessage;
 import com.lunarclient.apollo.player.v1.PlayerHandshakeMessage;
 import java.util.List;
 import java.util.UUID;
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jspecify.annotations.NonNull;
 
 public class ApolloPacketReceiveProtoListener implements PluginMessageListener {
 
@@ -50,7 +58,7 @@ public class ApolloPacketReceiveProtoListener implements PluginMessageListener {
     }
 
     @Override
-    public void onPluginMessageReceived(String s, Player player, byte[] bytes) {
+    public void onPluginMessageReceived(@NonNull String channel, @NonNull Player player, byte[] bytes) {
         try {
             Any any = Any.parseFrom(bytes);
 
@@ -67,6 +75,8 @@ public class ApolloPacketReceiveProtoListener implements PluginMessageListener {
                 this.onPlayerChatClose(any.unpack(PlayerChatCloseMessage.class));
             } else if (any.is(PlayerUseItemMessage.class)) {
                 this.onPlayerUseItem(any.unpack(PlayerUseItemMessage.class));
+            } else if (any.is(PlayerUseItemBucketMessage.class)) {
+                this.onPlayerUseItemBucket(any.unpack(PlayerUseItemBucketMessage.class));
             }
         } catch (InvalidProtocolBufferException e) {
             throw new RuntimeException(e);
@@ -74,10 +84,10 @@ public class ApolloPacketReceiveProtoListener implements PluginMessageListener {
     }
 
     private void onPlayerHandshake(PlayerHandshakeMessage message) {
+        EmbeddedCheckoutSupport checkoutSupport = message.getEmbeddedCheckoutSupport();
         MinecraftVersion minecraftVersion = message.getMinecraftVersion();
 
         LunarClientVersion lunarClientVersion = message.getLunarClientVersion();
-        EmbeddedCheckoutSupport checkoutSupport = message.getEmbeddedCheckoutSupport();
         String gitBranch = lunarClientVersion.getGitBranch();
         String gitCommit = lunarClientVersion.getGitCommit();
         String semVer = lunarClientVersion.getSemver();
@@ -124,9 +134,32 @@ public class ApolloPacketReceiveProtoListener implements PluginMessageListener {
         boolean mainHand = message.getMainHand();
     }
 
+    private void onPlayerUseItemBucket(PlayerUseItemBucketMessage message) {
+        long instantiationTimeMs = ProtobufUtil.toJavaTimestamp(message.getPacketInfo().getInstantiationTime());
+
+        PlayerInfo playerInfo = message.getPlayerInfo();
+        this.onPlayerInfo(playerInfo);
+
+        RayTraceResult rayTraceResult = message.getRayTraceResult();
+
+        if (rayTraceResult.hasBlock()) {
+            BlockHit blockHit = rayTraceResult.getBlock();
+
+            Location hitLocation = blockHit.getHitLocation();
+            BlockLocation blockLocation = blockHit.getBlockLocation();
+            Direction direction = blockHit.getDirection();
+        } else if (rayTraceResult.hasEntity()) {
+            EntityHit entityHit = rayTraceResult.getEntity();
+            Location hitLocation = entityHit.getHitLocation();
+            EntityId entityId = entityHit.getEntityId();
+        } else {
+            // Miss
+        }
+    }
+
     private void onPlayerInfo(PlayerInfo info) {
         UUID uuid = ProtobufUtil.toJavaUuid(info.getPlayerUuid());
-        Location location = ProtobufUtil.toBukkitLocation(info.getLocation());
+        org.bukkit.Location location = ProtobufUtil.toBukkitLocation(info.getLocation());
         boolean sneaking = info.getSneaking();
         boolean sprinting = info.getSprinting();
         boolean jumping = info.getJumping();

--- a/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
+++ b/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
@@ -50,7 +50,7 @@ public final class ProtobufPacketUtil {
     private static final Table<String, String, Value> CONFIG_MODULE_PROPERTIES = HashBasedTable.create();
 
     static {
-        // Module Options that the client needs to notified about, these properties are sent with the enable module packet
+        // Module Options the client needs to be notified about. These properties are sent with the enable module packet.
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());

--- a/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
+++ b/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
@@ -41,9 +41,9 @@ import org.bukkit.entity.Player;
 
 public final class ProtobufPacketUtil {
 
-    private static final List<String> APOLLO_MODULES = Arrays.asList("limb", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
-        "entity", "glow", "hologram", "mod_setting", "nametag", "nick_hider", "notification", "packet_enrichment", "rich_presence",
-        "server_rule", "staff_mod", "stopwatch", "team", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
+    private static final List<String> APOLLO_MODULES = Arrays.asList("auto_text_hotkey", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
+        "entity", "glint", "glow", "hologram", "inventory", "limb", "mod_setting", "nametag", "nick_hider", "notification", "pay_now", "packet_enrichment",
+        "rich_presence", "saturation", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
     );
 
     // Module Id -> Option key -> Value
@@ -53,6 +53,11 @@ public final class ProtobufPacketUtil {
         // Module Options that the client needs to notified about, these properties are sent with the enable module packet
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
+        CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());
+        CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", Value.newBuilder().setBoolValue(false).build());
+        CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", Value.newBuilder().setBoolValue(false).build());
+        CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item.send-packet", Value.newBuilder().setBoolValue(false).build());
+        CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item-bucket.send-packet", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-game", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-commands", Value.newBuilder().setListValue(
             ListValue.newBuilder().addAllValues(Arrays.asList(


### PR DESCRIPTION
## Overview

**Description:**
Provide examples for serverbound Apollo packets through the `apollo:json` channel.

**Changes:**

Json & Proto:
- Add missing packet enrichment module config keys
- Add missing modules from the util module list
- Add player item use bucket example

Json specific changes:
- Add Transfer Module examples
- Add serverbound & roundtrip examples
- Add `toJavaUuid`, `toJavaTimestamp`, `toBukkitLocation`, `toBukkitPlayerLocation` to `JsonUtil`

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
