### PR TITLE
Add `PERSIST_COLORS_ON_UNLOAD` to ColoredFireModule

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/module/coloredfire/ColoredFireModule.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/coloredfire/ColoredFireModule.java
@@ -25,7 +25,10 @@ package com.lunarclient.apollo.module.coloredfire;
 
 import com.lunarclient.apollo.module.ApolloModule;
 import com.lunarclient.apollo.module.ModuleDefinition;
+import com.lunarclient.apollo.option.Option;
+import com.lunarclient.apollo.option.SimpleOption;
 import com.lunarclient.apollo.recipients.Recipients;
+import io.leangen.geantyref.TypeToken;
 import java.awt.Color;
 import java.util.UUID;
 import org.jetbrains.annotations.ApiStatus;
@@ -38,6 +41,22 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.NonExtendable
 @ModuleDefinition(id = "colored_fire", name = "Colored Fire")
 public abstract class ColoredFireModule extends ApolloModule {
+
+    /**
+     * Whether fire colors should persist when a player unloads from the tracker.
+     *
+     * @since 1.2.7
+     */
+    public static final SimpleOption<Boolean> PERSIST_COLORS_ON_UNLOAD = Option.<Boolean>builder()
+        .comment("Set to 'true' to keep fire colors when players unload from the tracker, otherwise 'false'.")
+        .node("persist-colors-on-unload").type(TypeToken.get(Boolean.class))
+        .defaultValue(false).notifyClient().build();
+
+    ColoredFireModule() {
+        this.registerOptions(
+            ColoredFireModule.PERSIST_COLORS_ON_UNLOAD
+        );
+    }
 
     @Override
     public boolean isClientNotify() {

--- a/docs/developers/lightweight/json/packet-util.mdx
+++ b/docs/developers/lightweight/json/packet-util.mdx
@@ -33,6 +33,7 @@ private static final Table<String, String, Object> CONFIG_MODULE_PROPERTIES = Ha
 static {
     // Module Options the client needs to be notified about. These properties are sent with the enable module packet.
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
+    CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", false);
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", false);

--- a/docs/developers/lightweight/protobuf/packet-util.mdx
+++ b/docs/developers/lightweight/protobuf/packet-util.mdx
@@ -33,6 +33,7 @@ private static final Table<String, String, Value> CONFIG_MODULE_PROPERTIES = Has
 static {
     // Module Options the client needs to be notified about. These properties are sent with the enable module packet.
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
+    CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", Value.newBuilder().setBoolValue(false).build());

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
@@ -51,6 +51,7 @@ public final class JsonPacketUtil {
     static {
         // Module Options the client needs to be notified about. These properties are sent with the enable module packet.
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
+        CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", false);
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", false);

--- a/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
+++ b/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
@@ -52,6 +52,7 @@ public final class ProtobufPacketUtil {
     static {
         // Module Options the client needs to be notified about. These properties are sent with the enable module packet.
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
+        CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", Value.newBuilder().setBoolValue(false).build());


### PR DESCRIPTION
## Overview

**Description:**
Add `PERSIST_COLORS_ON_UNLOAD` option to the ColoredFireModule to control whether fire colors are removed when a player unloads from the tracker

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
