### PR TITLE
Velocity - Fix legacy player detection

### DIFF
--- a/platform/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
+++ b/platform/velocity/src/main/java/com/lunarclient/apollo/ApolloVelocityPlatform.java
@@ -94,6 +94,7 @@ import com.velocitypowered.api.plugin.PluginDescription;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.messages.ChannelRegistrar;
+import com.velocitypowered.api.proxy.messages.LegacyChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -118,6 +119,7 @@ import lombok.Getter;
 public final class ApolloVelocityPlatform implements ApolloPlatform {
 
     public static MinecraftChannelIdentifier PLUGIN_CHANNEL;
+    public static LegacyChannelIdentifier LEGACY_PLUGIN_CHANNEL;
 
     @Getter private static ApolloVelocityPlatform instance;
 
@@ -227,6 +229,7 @@ public final class ApolloVelocityPlatform implements ApolloPlatform {
 
         ChannelRegistrar channelRegistrar = this.server.getChannelRegistrar();
         channelRegistrar.register(ApolloVelocityPlatform.PLUGIN_CHANNEL);
+        channelRegistrar.register(ApolloVelocityPlatform.LEGACY_PLUGIN_CHANNEL);
         channelRegistrar.register(ApolloMetadataListener.FML_HANDSHAKE_CHANNEL);
 
         CommandManager commandManager = this.server.getCommandManager();
@@ -250,6 +253,7 @@ public final class ApolloVelocityPlatform implements ApolloPlatform {
 
     static {
         PLUGIN_CHANNEL = MinecraftChannelIdentifier.create("lunar", "apollo");
+        LEGACY_PLUGIN_CHANNEL = new LegacyChannelIdentifier(ApolloManager.PLUGIN_MESSAGE_CHANNEL);
     }
 
 }

--- a/platform/velocity/src/main/java/com/lunarclient/apollo/listener/ApolloPlayerListener.java
+++ b/platform/velocity/src/main/java/com/lunarclient/apollo/listener/ApolloPlayerListener.java
@@ -25,7 +25,6 @@ package com.lunarclient.apollo.listener;
 
 import com.lunarclient.apollo.Apollo;
 import com.lunarclient.apollo.ApolloManager;
-import com.lunarclient.apollo.ApolloVelocityPlatform;
 import com.lunarclient.apollo.player.ApolloPlayerManagerImpl;
 import com.lunarclient.apollo.wrapper.VelocityApolloPlayer;
 import com.velocitypowered.api.event.Subscribe;
@@ -33,6 +32,7 @@ import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.PlayerChannelRegisterEvent;
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 
 /**
  * Handles registration and un-registration of Apollo players.
@@ -49,7 +49,15 @@ public final class ApolloPlayerListener {
      */
     @Subscribe
     public void onPlayerRegisterChannel(PlayerChannelRegisterEvent event) {
-        if (!event.getChannels().contains(ApolloVelocityPlatform.PLUGIN_CHANNEL)) {
+        boolean registered = false;
+        for (ChannelIdentifier channel : event.getChannels()) {
+            if (channel.getId().equals(ApolloManager.PLUGIN_MESSAGE_CHANNEL)) {
+                registered = true;
+                break;
+            }
+        }
+
+        if (!registered) {
             return;
         }
 
@@ -65,7 +73,7 @@ public final class ApolloPlayerListener {
      */
     @Subscribe
     public void onPluginMessage(PluginMessageEvent event) {
-        if (!event.getIdentifier().equals(ApolloVelocityPlatform.PLUGIN_CHANNEL)) {
+        if (!event.getIdentifier().getId().equals(ApolloManager.PLUGIN_MESSAGE_CHANNEL)) {
             return;
         }
 


### PR DESCRIPTION
## Overview

**Description:**
Fixes Lunar Client detection for legacy players connecting through a Velocity proxy.

**Changes:**
- Register a `LegacyChannelIdentifier` for `lunar:apollo` alongside the existing `MinecraftChannelIdentifier` so Velocity surfaces inbound channel registrations and plugin messages from pre-1.13 clients

**Related Issue:**
#273 

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
