### PR TITLE
Add `ALLOW_DIG_AND_USE` to Combat Module

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/module/combat/CombatModule.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/combat/CombatModule.java
@@ -49,12 +49,12 @@ public final class CombatModule extends ApolloModule {
 
     /**
      * Whether the player can attack and use an item at the same time,
-     * like in 1.7. Only applies to players on 1.8.
+     * like in 1.7. Applies to all versions 1.8 and above.
      *
      * @since 1.2.8
      */
     public static final SimpleOption<Boolean> ALLOW_ATTACK_AND_USE = Option.<Boolean>builder()
-        .comment("Set to 'true' to allow attacking and using an item at the same time on 1.8, otherwise 'false'.")
+        .comment("Set to 'true' to allow attacking and using an item at the same time on all versions 1.8 and above, otherwise 'false'.")
         .node("allow-attack-and-use").type(TypeToken.get(Boolean.class))
         .defaultValue(false).notifyClient().build();
 

--- a/api/src/main/java/com/lunarclient/apollo/module/combat/CombatModule.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/combat/CombatModule.java
@@ -47,9 +47,21 @@ public final class CombatModule extends ApolloModule {
         .node("disable-miss-penalty").type(TypeToken.get(Boolean.class))
         .defaultValue(false).notifyClient().build();
 
+    /**
+     * Whether the player can attack and use an item at the same time,
+     * like in 1.7. Only applies to players on 1.8.
+     *
+     * @since 1.2.8
+     */
+    public static final SimpleOption<Boolean> ALLOW_ATTACK_AND_USE = Option.<Boolean>builder()
+        .comment("Set to 'true' to allow attacking and using an item at the same time on 1.8, otherwise 'false'.")
+        .node("allow-attack-and-use").type(TypeToken.get(Boolean.class))
+        .defaultValue(false).notifyClient().build();
+
     CombatModule() {
         this.registerOptions(
-            CombatModule.DISABLE_MISS_PENALTY
+            CombatModule.DISABLE_MISS_PENALTY,
+            CombatModule.ALLOW_ATTACK_AND_USE
         );
     }
 

--- a/api/src/main/java/com/lunarclient/apollo/module/combat/CombatModule.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/combat/CombatModule.java
@@ -40,28 +40,32 @@ public final class CombatModule extends ApolloModule {
     /**
      * Whether the player gets a hit delay for a missed hit.
      *
+     * <p>Enabling this option may cause compatibility issues with anti-cheats.</p>
+     *
      * @since 1.0.4
      */
     public static final SimpleOption<Boolean> DISABLE_MISS_PENALTY = Option.<Boolean>builder()
-        .comment("Set to 'true' to remove the miss penalty on all versions 1.8 and above, otherwise 'false'.")
+        .comment("Set to 'true' to remove the miss penalty on all versions 1.8 and above, otherwise 'false'. Enabling this option may cause compatibility issues with anti-cheats.")
         .node("disable-miss-penalty").type(TypeToken.get(Boolean.class))
         .defaultValue(false).notifyClient().build();
 
     /**
-     * Whether the player can attack and use an item at the same time,
+     * Whether the player can dig and use an item at the same time,
      * like in 1.7. Applies to all versions 1.8 and above.
+     *
+     * <p>Enabling this option may cause compatibility issues with anti-cheats.</p>
      *
      * @since 1.2.8
      */
-    public static final SimpleOption<Boolean> ALLOW_ATTACK_AND_USE = Option.<Boolean>builder()
-        .comment("Set to 'true' to allow attacking and using an item at the same time on all versions 1.8 and above, otherwise 'false'.")
-        .node("allow-attack-and-use").type(TypeToken.get(Boolean.class))
+    public static final SimpleOption<Boolean> ALLOW_DIG_AND_USE = Option.<Boolean>builder()
+        .comment("Set to 'true' to allow digging and using an item at the same time on all versions 1.8 and above, otherwise 'false'. Enabling this option may cause compatibility issues with anti-cheats.")
+        .node("allow-dig-and-use").type(TypeToken.get(Boolean.class))
         .defaultValue(false).notifyClient().build();
 
     CombatModule() {
         this.registerOptions(
             CombatModule.DISABLE_MISS_PENALTY,
-            CombatModule.ALLOW_ATTACK_AND_USE
+            CombatModule.ALLOW_DIG_AND_USE
         );
     }
 

--- a/docs/developers/lightweight/json/packet-util.mdx
+++ b/docs/developers/lightweight/json/packet-util.mdx
@@ -35,7 +35,7 @@ static {
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
     CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", false);
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
-    CONFIG_MODULE_PROPERTIES.put("combat", "allow-attack-and-use", false);
+    CONFIG_MODULE_PROPERTIES.put("combat", "allow-dig-and-use", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", false);

--- a/docs/developers/lightweight/json/packet-util.mdx
+++ b/docs/developers/lightweight/json/packet-util.mdx
@@ -35,6 +35,7 @@ static {
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
     CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", false);
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
+    CONFIG_MODULE_PROPERTIES.put("combat", "allow-attack-and-use", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", false);

--- a/docs/developers/lightweight/protobuf/packet-util.mdx
+++ b/docs/developers/lightweight/protobuf/packet-util.mdx
@@ -35,7 +35,7 @@ static {
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
     CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
-    CONFIG_MODULE_PROPERTIES.put("combat", "allow-attack-and-use", Value.newBuilder().setBoolValue(false).build());
+    CONFIG_MODULE_PROPERTIES.put("combat", "allow-dig-and-use", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", Value.newBuilder().setBoolValue(false).build());

--- a/docs/developers/lightweight/protobuf/packet-util.mdx
+++ b/docs/developers/lightweight/protobuf/packet-util.mdx
@@ -35,6 +35,7 @@ static {
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
     CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
+    CONFIG_MODULE_PROPERTIES.put("combat", "allow-attack-and-use", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", Value.newBuilder().setBoolValue(false).build());

--- a/docs/developers/modules/combat.mdx
+++ b/docs/developers/modules/combat.mdx
@@ -7,7 +7,7 @@ import { Callout, Tab, Tabs } from 'nextra-theme-docs'
 The combat module allows you to modify certain aspects of combat that are usually handled client-sided.
 
 - Adds the ability to disable the miss penalty, on all versions 1.8 and above.
-- Adds the ability to attack and use an item at the same time, like in 1.7, on all versions 1.8 and above.
+- Adds the ability to dig and use an item at the same time, like in 1.7, on all versions 1.8 and above.
 
 ### Sample Code
 Explore each integration by cycling through each tab, to find the best fit for your requirements and needs.
@@ -28,11 +28,11 @@ public void setDisableMissPenalty(boolean value) {
 }
 ```
 
-### Toggle Attack and Use
+### Toggle Dig and Use
 
 ```java
-public void setAllowAttackAndUse(boolean value) {
-    this.combatModule.getOptions().set(CombatModule.ALLOW_ATTACK_AND_USE, value);
+public void setAllowDigAndUse(boolean value) {
+    this.combatModule.getOptions().set(CombatModule.ALLOW_DIG_AND_USE, value);
 }
 ```
 
@@ -56,12 +56,12 @@ public void setDisableMissPenalty(boolean value) {
 }
 ```
 
-### Toggle Attack and Use
+### Toggle Dig and Use
 
 ```java
-public void setAllowAttackAndUse(boolean value) {
+public void setAllowDigAndUse(boolean value) {
     Map<String, Value> properties = new HashMap<>();
-    properties.put("allow-attack-and-use", Value.newBuilder().setBoolValue(value).build());
+    properties.put("allow-dig-and-use", Value.newBuilder().setBoolValue(value).build());
 
     ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("combat", properties);
     ProtobufPacketUtil.broadcastPacket(settings);
@@ -88,12 +88,12 @@ public void setDisableMissPenalty(boolean value) {
 }
 ```
 
-### Toggle Attack and Use
+### Toggle Dig and Use
 
 ```java
-public void setAllowAttackAndUse(boolean value) {
+public void setAllowDigAndUse(boolean value) {
     Map<String, Object> properties = new HashMap<>();
-    properties.put("allow-attack-and-use", value);
+    properties.put("allow-dig-and-use", value);
 
     JsonObject message = JsonUtil.createEnableModuleObjectWithType("combat", properties);
     JsonPacketUtil.broadcastPacket(message);
@@ -107,12 +107,12 @@ public void setAllowAttackAndUse(boolean value) {
 ## Available options
 
 - __`DISABLE_MISS_PENALTY`__
-    - Whether the player gets a hit delay for a missed hit.
+    - Whether the player gets a hit delay for a missed hit. Enabling this option may cause compatibility issues with anti-cheats.
     - Values
         - Type: `Boolean`
         - Default: `false`
-- __`ALLOW_ATTACK_AND_USE`__
-    - Whether the player can attack and use an item at the same time, like in 1.7. Applies to all versions 1.8 and above.
+- __`ALLOW_DIG_AND_USE`__
+    - Whether the player can dig and use an item at the same time, like in 1.7. Applies to all versions 1.8 and above. Enabling this option may cause compatibility issues with anti-cheats.
     - Values
         - Type: `Boolean`
         - Default: `false`

--- a/docs/developers/modules/combat.mdx
+++ b/docs/developers/modules/combat.mdx
@@ -7,7 +7,7 @@ import { Callout, Tab, Tabs } from 'nextra-theme-docs'
 The combat module allows you to modify certain aspects of combat that are usually handled client-sided.
 
 - Adds the ability to disable the miss penalty, on all versions 1.8 and above.
-- Adds the ability to attack and use an item at the same time, like in 1.7, for players on 1.8.
+- Adds the ability to attack and use an item at the same time, like in 1.7, on all versions 1.8 and above.
 
 ### Sample Code
 Explore each integration by cycling through each tab, to find the best fit for your requirements and needs.
@@ -112,7 +112,7 @@ public void setAllowAttackAndUse(boolean value) {
         - Type: `Boolean`
         - Default: `false`
 - __`ALLOW_ATTACK_AND_USE`__
-    - Whether the player can attack and use an item at the same time, like in 1.7. Only applies to players on 1.8.
+    - Whether the player can attack and use an item at the same time, like in 1.7. Applies to all versions 1.8 and above.
     - Values
         - Type: `Boolean`
         - Default: `false`

--- a/docs/developers/modules/combat.mdx
+++ b/docs/developers/modules/combat.mdx
@@ -44,7 +44,7 @@ public void setAllowDigAndUse(boolean value) {
 **Lightweight Protobuf examples.** See [Lightweight Protobuf](/apollo/developers/lightweight/protobuf) for setup.
 </Callout>
 
-### Toggle Miss Penalty
+**Toggle Miss Penalty**
 
 ```java
 public void setDisableMissPenalty(boolean value) {
@@ -56,7 +56,7 @@ public void setDisableMissPenalty(boolean value) {
 }
 ```
 
-### Toggle Dig and Use
+**Toggle Dig and Use**
 
 ```java
 public void setAllowDigAndUse(boolean value) {
@@ -76,7 +76,7 @@ public void setAllowDigAndUse(boolean value) {
 **Lightweight JSON examples.** See [Lightweight JSON](/apollo/developers/lightweight/json) for setup.
 </Callout>
 
-### Toggle Miss Penalty
+**Toggle Miss Penalty**
 
 ```java
 public void setDisableMissPenalty(boolean value) {
@@ -88,7 +88,7 @@ public void setDisableMissPenalty(boolean value) {
 }
 ```
 
-### Toggle Dig and Use
+**Toggle Dig and Use**
 
 ```java
 public void setAllowDigAndUse(boolean value) {

--- a/docs/developers/modules/combat.mdx
+++ b/docs/developers/modules/combat.mdx
@@ -7,6 +7,7 @@ import { Callout, Tab, Tabs } from 'nextra-theme-docs'
 The combat module allows you to modify certain aspects of combat that are usually handled client-sided.
 
 - Adds the ability to disable the miss penalty, on all versions 1.8 and above.
+- Adds the ability to attack and use an item at the same time, like in 1.7, for players on 1.8.
 
 ### Sample Code
 Explore each integration by cycling through each tab, to find the best fit for your requirements and needs.
@@ -27,6 +28,14 @@ public void setDisableMissPenalty(boolean value) {
 }
 ```
 
+### Toggle Attack and Use
+
+```java
+public void setAllowAttackAndUse(boolean value) {
+    this.combatModule.getOptions().set(CombatModule.ALLOW_ATTACK_AND_USE, value);
+}
+```
+
 </Tab>
 
 <Tab>
@@ -41,6 +50,18 @@ public void setDisableMissPenalty(boolean value) {
 public void setDisableMissPenalty(boolean value) {
     Map<String, Value> properties = new HashMap<>();
     properties.put("disable-miss-penalty", Value.newBuilder().setBoolValue(value).build());
+
+    ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("combat", properties);
+    ProtobufPacketUtil.broadcastPacket(settings);
+}
+```
+
+### Toggle Attack and Use
+
+```java
+public void setAllowAttackAndUse(boolean value) {
+    Map<String, Value> properties = new HashMap<>();
+    properties.put("allow-attack-and-use", Value.newBuilder().setBoolValue(value).build());
 
     ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("combat", properties);
     ProtobufPacketUtil.broadcastPacket(settings);
@@ -67,6 +88,18 @@ public void setDisableMissPenalty(boolean value) {
 }
 ```
 
+### Toggle Attack and Use
+
+```java
+public void setAllowAttackAndUse(boolean value) {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("allow-attack-and-use", value);
+
+    JsonObject message = JsonUtil.createEnableModuleObjectWithType("combat", properties);
+    JsonPacketUtil.broadcastPacket(message);
+}
+```
+
 </Tab>
 
 </Tabs>
@@ -75,6 +108,11 @@ public void setDisableMissPenalty(boolean value) {
 
 - __`DISABLE_MISS_PENALTY`__
     - Whether the player gets a hit delay for a missed hit.
+    - Values
+        - Type: `Boolean`
+        - Default: `false`
+- __`ALLOW_ATTACK_AND_USE`__
+    - Whether the player can attack and use an item at the same time, like in 1.7. Only applies to players on 1.8.
     - Values
         - Type: `Boolean`
         - Default: `false`

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
@@ -53,6 +53,7 @@ public final class JsonPacketUtil {
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
         CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", false);
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
+        CONFIG_MODULE_PROPERTIES.put("combat", "allow-attack-and-use", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", false);

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
@@ -53,7 +53,7 @@ public final class JsonPacketUtil {
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
         CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", false);
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
-        CONFIG_MODULE_PROPERTIES.put("combat", "allow-attack-and-use", false);
+        CONFIG_MODULE_PROPERTIES.put("combat", "allow-dig-and-use", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", false);

--- a/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
+++ b/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
@@ -54,7 +54,7 @@ public final class ProtobufPacketUtil {
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
         CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
-        CONFIG_MODULE_PROPERTIES.put("combat", "allow-attack-and-use", Value.newBuilder().setBoolValue(false).build());
+        CONFIG_MODULE_PROPERTIES.put("combat", "allow-dig-and-use", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", Value.newBuilder().setBoolValue(false).build());

--- a/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
+++ b/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
@@ -54,6 +54,7 @@ public final class ProtobufPacketUtil {
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
         CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
+        CONFIG_MODULE_PROPERTIES.put("combat", "allow-attack-and-use", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", Value.newBuilder().setBoolValue(false).build());


### PR DESCRIPTION
## Overview

**Description:**
Add `ALLOW_DIG_AND_USE` option to the CombatModule to control whether players on 1.8 can attack and use an item at the same time, like in 1.7 (e.g. mining while blocking, or consuming items while breaking blocks)

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
