### PR TITLE
Server Link Module - Configurable Button Placement

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/module/combat/CombatModule.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/combat/CombatModule.java
@@ -45,7 +45,10 @@ public final class CombatModule extends ApolloModule {
      * @since 1.0.4
      */
     public static final SimpleOption<Boolean> DISABLE_MISS_PENALTY = Option.<Boolean>builder()
-        .comment("Set to 'true' to remove the miss penalty on all versions 1.8 and above, otherwise 'false'. Enabling this option may cause compatibility issues with anti-cheats.")
+        .comment(
+            "Set to 'true' to remove the miss penalty on all versions 1.8 and above, otherwise 'false'.",
+            "Enabling this option may cause compatibility issues with anti-cheats."
+        )
         .node("disable-miss-penalty").type(TypeToken.get(Boolean.class))
         .defaultValue(false).notifyClient().build();
 
@@ -58,7 +61,10 @@ public final class CombatModule extends ApolloModule {
      * @since 1.2.8
      */
     public static final SimpleOption<Boolean> ALLOW_DIG_AND_USE = Option.<Boolean>builder()
-        .comment("Set to 'true' to allow digging and using an item at the same time on all versions 1.8 and above, otherwise 'false'. Enabling this option may cause compatibility issues with anti-cheats.")
+        .comment(
+            "Set to 'true' to allow digging and using an item at the same time on all versions 1.8 and above, otherwise 'false'.",
+            "Enabling this option may cause compatibility issues with anti-cheats."
+        )
         .node("allow-dig-and-use").type(TypeToken.get(Boolean.class))
         .defaultValue(false).notifyClient().build();
 

--- a/api/src/main/java/com/lunarclient/apollo/module/serverlink/ServerLinkModule.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/serverlink/ServerLinkModule.java
@@ -26,7 +26,12 @@ package com.lunarclient.apollo.module.serverlink;
 import com.lunarclient.apollo.common.icon.ResourceLocationIcon;
 import com.lunarclient.apollo.module.ApolloModule;
 import com.lunarclient.apollo.module.ModuleDefinition;
+import com.lunarclient.apollo.module.serverlink.pausemenu.LegacyServerLinkPlacement;
+import com.lunarclient.apollo.module.serverlink.pausemenu.ModernServerLinkPlacement;
+import com.lunarclient.apollo.option.EnumOption;
+import com.lunarclient.apollo.option.Option;
 import com.lunarclient.apollo.recipients.Recipients;
+import io.leangen.geantyref.TypeToken;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -41,6 +46,49 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.NonExtendable
 @ModuleDefinition(id = "server_link", name = "Server Link")
 public abstract class ServerLinkModule extends ApolloModule {
+
+    /**
+     * Controls where the server links button is placed in the pause menu
+     * (1.7-1.12), where it is added on a new line by default.
+     *
+     * @since 1.2.8
+     */
+    public static final EnumOption<LegacyServerLinkPlacement> LEGACY_BUTTON_PLACEMENT = Option.<LegacyServerLinkPlacement>enumerator()
+        .comment(
+            "Where the server links button appears in the pause menu (1.7-1.12), added on a new line by default.",
+            " 'NEW_ROW' adds a dedicated row.",
+            " 'REPLACE_ACHIEVEMENTS' reuses the achievements button.",
+            " 'REPLACE_STATISTICS' reuses the statistics button."
+        )
+        .node("legacy-button-placement").type(TypeToken.get(LegacyServerLinkPlacement.class))
+        .defaultValue(LegacyServerLinkPlacement.NEW_ROW).notifyClient().build();
+
+    /**
+     * Controls where the server links button is placed in the pause menu
+     * (1.16.1+), where it replaces the existing report bugs button by default.
+     *
+     * <p>On 1.21 and above the server links button is handled natively and this
+     * option has no effect.</p>
+     *
+     * @since 1.2.8
+     */
+    public static final EnumOption<ModernServerLinkPlacement> MODERN_BUTTON_PLACEMENT = Option.<ModernServerLinkPlacement>enumerator()
+        .comment(
+            "Where the server links button appears in the pause menu (1.16.1+), replaces the existing report bugs button by default.",
+            " 'REPLACE_REPORT_BUGS' reuses the report bugs button.",
+            " 'REPLACE_ACHIEVEMENTS' reuses the advancements button.",
+            " 'REPLACE_STATISTICS' reuses the statistics button.",
+            "Has no effect on 1.21+ (handled natively)."
+        )
+        .node("modern-button-placement").type(TypeToken.get(ModernServerLinkPlacement.class))
+        .defaultValue(ModernServerLinkPlacement.REPLACE_REPORT_BUGS).notifyClient().build();
+
+    ServerLinkModule() {
+        this.registerOptions(
+            ServerLinkModule.LEGACY_BUTTON_PLACEMENT,
+            ServerLinkModule.MODERN_BUTTON_PLACEMENT
+        );
+    }
 
     /**
      * Overrides the server link menu title image for the {@link Recipients}.

--- a/api/src/main/java/com/lunarclient/apollo/module/serverlink/pausemenu/LegacyServerLinkPlacement.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/serverlink/pausemenu/LegacyServerLinkPlacement.java
@@ -21,25 +21,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.lunarclient.apollo.example.module.impl;
+package com.lunarclient.apollo.module.serverlink.pausemenu;
 
-import com.lunarclient.apollo.example.module.ApolloModuleExample;
-import org.bukkit.entity.Player;
+/**
+ * Represents where the server links button is placed in the pause menu
+ * (1.7-1.12), where it is added on a new line by default.
+ *
+ * @since 1.2.8
+ */
+public enum LegacyServerLinkPlacement {
 
-public abstract class ServerLinkExample extends ApolloModuleExample {
+    /**
+     * Adds the server links button on a dedicated new row, shifting the
+     * remaining buttons down.
+     *
+     * @since 1.2.8
+     */
+    NEW_ROW,
 
-    public abstract void overrideServerLinkResourceExample(Player viewer);
+    /**
+     * Replaces the vanilla achievements button with the server links button.
+     *
+     * @since 1.2.8
+     */
+    REPLACE_ACHIEVEMENTS,
 
-    public abstract void resetServerLinkResourceExample(Player viewer);
-
-    public abstract void addServerLinkExample(Player viewer);
-
-    public abstract void removeServerLinkExample(Player viewer);
-
-    public abstract void resetServerLinksExample(Player viewer);
-
-    public abstract void setLegacyButtonPlacementExample(String placement);
-
-    public abstract void setModernButtonPlacementExample(String placement);
+    /**
+     * Replaces the vanilla statistics button with the server links button.
+     *
+     * @since 1.2.8
+     */
+    REPLACE_STATISTICS
 
 }

--- a/api/src/main/java/com/lunarclient/apollo/module/serverlink/pausemenu/ModernServerLinkPlacement.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/serverlink/pausemenu/ModernServerLinkPlacement.java
@@ -21,25 +21,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.lunarclient.apollo.example.module.impl;
+package com.lunarclient.apollo.module.serverlink.pausemenu;
 
-import com.lunarclient.apollo.example.module.ApolloModuleExample;
-import org.bukkit.entity.Player;
+/**
+ * Represents where the server links button is placed in the pause menu
+ * (1.16.1+), where it replaces the existing report bugs button by default.
+ *
+ * <p>On 1.21 and above the server links button is handled natively and this
+ * option has no effect.</p>
+ *
+ * @since 1.2.8
+ */
+public enum ModernServerLinkPlacement {
 
-public abstract class ServerLinkExample extends ApolloModuleExample {
+    /**
+     * Replaces the report bugs button with the server links button.
+     *
+     * @since 1.2.8
+     */
+    REPLACE_REPORT_BUGS,
 
-    public abstract void overrideServerLinkResourceExample(Player viewer);
+    /**
+     * Replaces the vanilla advancements button with the server links button.
+     *
+     * @since 1.2.8
+     */
+    REPLACE_ACHIEVEMENTS,
 
-    public abstract void resetServerLinkResourceExample(Player viewer);
-
-    public abstract void addServerLinkExample(Player viewer);
-
-    public abstract void removeServerLinkExample(Player viewer);
-
-    public abstract void resetServerLinksExample(Player viewer);
-
-    public abstract void setLegacyButtonPlacementExample(String placement);
-
-    public abstract void setModernButtonPlacementExample(String placement);
+    /**
+     * Replaces the vanilla statistics button with the server links button.
+     *
+     * @since 1.2.8
+     */
+    REPLACE_STATISTICS
 
 }

--- a/api/src/main/java/com/lunarclient/apollo/option/OptionBuilder.java
+++ b/api/src/main/java/com/lunarclient/apollo/option/OptionBuilder.java
@@ -87,6 +87,22 @@ public abstract class OptionBuilder<V, M extends OptionBuilder<V, M, I>, I exten
     }
 
     /**
+     * Sets the option comment to the provided lines, joined with a newline, and
+     * returns this builder.
+     *
+     * <p>Each provided line is rendered as its own comment line in the
+     * configuration.</p>
+     *
+     * @param lines the comment lines
+     * @return this builder
+     * @since 1.2.8
+     */
+    public M comment(@NonNull String... lines) {
+        this.comment = String.join("\n", lines);
+        return (M) this;
+    }
+
+    /**
      * Sets the option default value to the provided {@code T} value and
      * returns this builder.
      *

--- a/docs/developers/lightweight/json/packet-util.mdx
+++ b/docs/developers/lightweight/json/packet-util.mdx
@@ -15,7 +15,7 @@ To utilize Apollo Modules, first define a list of the modules you want to use:
 ```java
 private static final List<String> APOLLO_MODULES = Arrays.asList("auto_text_hotkey", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
     "entity", "glint", "glow", "hologram", "inventory", "limb", "mod_setting", "nametag", "nick_hider", "notification", "pay_now", "packet_enrichment",
-    "rich_presence", "saturation", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
+    "rich_presence", "saturation", "server_link", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
 );
 ```
 
@@ -41,6 +41,8 @@ static {
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item.send-packet", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item-bucket.send-packet", false);
+    CONFIG_MODULE_PROPERTIES.put("server_link", "legacy-button-placement", "NEW_ROW");
+    CONFIG_MODULE_PROPERTIES.put("server_link", "modern-button-placement", "REPLACE_REPORT_BUGS");
     CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-game", false);
     CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-commands", Arrays.asList("/server", "/servers", "/hub"));
     CONFIG_MODULE_PROPERTIES.put("server_rule", "disable-shaders", false);

--- a/docs/developers/lightweight/protobuf/packet-util.mdx
+++ b/docs/developers/lightweight/protobuf/packet-util.mdx
@@ -15,7 +15,7 @@ To utilize Apollo Modules, first define a list of the modules you want to use:
 ```java
 private static final List<String> APOLLO_MODULES = Arrays.asList("auto_text_hotkey", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
     "entity", "glint", "glow", "hologram", "inventory", "limb", "mod_setting", "nametag", "nick_hider", "notification", "pay_now", "packet_enrichment",
-    "rich_presence", "saturation", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
+    "rich_presence", "saturation", "server_link", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
 );
 ```
 
@@ -41,6 +41,8 @@ static {
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item.send-packet", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item-bucket.send-packet", Value.newBuilder().setBoolValue(false).build());
+    CONFIG_MODULE_PROPERTIES.put("server_link", "legacy-button-placement", Value.newBuilder().setStringValue("NEW_ROW").build());
+    CONFIG_MODULE_PROPERTIES.put("server_link", "modern-button-placement", Value.newBuilder().setStringValue("REPLACE_REPORT_BUGS").build());
     CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-game", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-commands", Value.newBuilder().setListValue(
         ListValue.newBuilder().addAllValues(Arrays.asList(

--- a/docs/developers/modules/serverlink.mdx
+++ b/docs/developers/modules/serverlink.mdx
@@ -100,6 +100,24 @@ public void resetServerLinksExample(Player viewer) {
 }
 ```
 
+### Set Legacy Button Placement
+
+```java
+public void setLegacyButtonPlacementExample(String placement) {
+    LegacyServerLinkPlacement legacyPlacement = LegacyServerLinkPlacement.valueOf(placement);
+    this.serverLinkModule.getOptions().set(ServerLinkModule.LEGACY_BUTTON_PLACEMENT, legacyPlacement);
+}
+```
+
+### Set Modern Button Placement
+
+```java
+public void setModernButtonPlacementExample(String placement) {
+    ModernServerLinkPlacement modernPlacement = ModernServerLinkPlacement.valueOf(placement);
+    this.serverLinkModule.getOptions().set(ServerLinkModule.MODERN_BUTTON_PLACEMENT, modernPlacement);
+}
+```
+
 ### `ServerLink` Options
 
 `.id(String)` sets a unique identifier for the server link.
@@ -205,6 +223,30 @@ public void resetServerLinksExample(Player viewer) {
 }
 ```
 
+**Set Legacy Button Placement**
+
+```java
+public void setLegacyButtonPlacementExample(String placement) {
+    Map<String, Value> properties = new HashMap<>();
+    properties.put("legacy-button-placement", Value.newBuilder().setStringValue(placement).build());
+
+    ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("server_link", properties);
+    ProtobufPacketUtil.broadcastPacket(settings);
+}
+```
+
+**Set Modern Button Placement**
+
+```java
+public void setModernButtonPlacementExample(String placement) {
+    Map<String, Value> properties = new HashMap<>();
+    properties.put("modern-button-placement", Value.newBuilder().setStringValue(placement).build());
+
+    ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("server_link", properties);
+    ProtobufPacketUtil.broadcastPacket(settings);
+}
+```
+
 </Tab>
 
 <Tab>
@@ -288,6 +330,44 @@ public void resetServerLinksExample(Player viewer) {
 }
 ```
 
+**Set Legacy Button Placement**
+
+```java
+public void setLegacyButtonPlacementExample(String placement) {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("legacy-button-placement", placement);
+
+    JsonObject message = JsonUtil.createEnableModuleObjectWithType("server_link", properties);
+    JsonPacketUtil.broadcastPacket(message);
+}
+```
+
+**Set Modern Button Placement**
+
+```java
+public void setModernButtonPlacementExample(String placement) {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("modern-button-placement", placement);
+
+    JsonObject message = JsonUtil.createEnableModuleObjectWithType("server_link", properties);
+    JsonPacketUtil.broadcastPacket(message);
+}
+```
+
 </Tab>
 
 </Tabs>
+
+## Available options
+
+- __`LEGACY_BUTTON_PLACEMENT`__
+    - Where the server links button appears in the pause menu (1.7-1.12), where it is added on a new line by default.
+    - Values
+        - Type: `LegacyServerLinkPlacement` (`NEW_ROW`, `REPLACE_ACHIEVEMENTS`, `REPLACE_STATISTICS`)
+        - Default: `NEW_ROW`
+
+- __`MODERN_BUTTON_PLACEMENT`__
+    - Where the server links button appears in the pause menu (1.16.1+), where it replaces the existing report bugs button by default. Has no effect on 1.21+ (handled natively).
+    - Values
+        - Type: `ModernServerLinkPlacement` (`REPLACE_REPORT_BUGS`, `REPLACE_ACHIEVEMENTS`, `REPLACE_STATISTICS`)
+        - Default: `REPLACE_REPORT_BUGS`

--- a/example/bukkit/api/src/main/java/com/lunarclient/apollo/example/api/module/ServerLinkApiExample.java
+++ b/example/bukkit/api/src/main/java/com/lunarclient/apollo/example/api/module/ServerLinkApiExample.java
@@ -29,6 +29,8 @@ import com.lunarclient.apollo.common.icon.ResourceLocationIcon;
 import com.lunarclient.apollo.example.module.impl.ServerLinkExample;
 import com.lunarclient.apollo.module.serverlink.ServerLink;
 import com.lunarclient.apollo.module.serverlink.ServerLinkModule;
+import com.lunarclient.apollo.module.serverlink.pausemenu.LegacyServerLinkPlacement;
+import com.lunarclient.apollo.module.serverlink.pausemenu.ModernServerLinkPlacement;
 import com.lunarclient.apollo.player.ApolloPlayer;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
@@ -96,6 +98,18 @@ public class ServerLinkApiExample extends ServerLinkExample {
     public void resetServerLinksExample(Player viewer) {
         Optional<ApolloPlayer> apolloPlayerOpt = Apollo.getPlayerManager().getPlayer(viewer.getUniqueId());
         apolloPlayerOpt.ifPresent(this.serverLinkModule::resetServerLinks);
+    }
+
+    @Override
+    public void setLegacyButtonPlacementExample(String placement) {
+        LegacyServerLinkPlacement legacyPlacement = LegacyServerLinkPlacement.valueOf(placement);
+        this.serverLinkModule.getOptions().set(ServerLinkModule.LEGACY_BUTTON_PLACEMENT, legacyPlacement);
+    }
+
+    @Override
+    public void setModernButtonPlacementExample(String placement) {
+        ModernServerLinkPlacement modernPlacement = ModernServerLinkPlacement.valueOf(placement);
+        this.serverLinkModule.getOptions().set(ServerLinkModule.MODERN_BUTTON_PLACEMENT, modernPlacement);
     }
 
 }

--- a/example/bukkit/common/src/main/java/com/lunarclient/apollo/example/command/ServerLinkCommand.java
+++ b/example/bukkit/common/src/main/java/com/lunarclient/apollo/example/command/ServerLinkCommand.java
@@ -25,6 +25,8 @@ package com.lunarclient.apollo.example.command;
 
 import com.lunarclient.apollo.example.ApolloExamplePlugin;
 import com.lunarclient.apollo.example.module.impl.ServerLinkExample;
+import java.util.Arrays;
+import java.util.List;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -32,6 +34,9 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 public class ServerLinkCommand implements CommandExecutor {
+
+    private static final List<String> LEGACY_PLACEMENTS = Arrays.asList("NEW_ROW", "REPLACE_ACHIEVEMENTS", "REPLACE_STATISTICS");
+    private static final List<String> MODERN_PLACEMENTS = Arrays.asList("REPLACE_REPORT_BUGS", "REPLACE_ACHIEVEMENTS", "REPLACE_STATISTICS");
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
@@ -42,8 +47,8 @@ public class ServerLinkCommand implements CommandExecutor {
 
         Player player = (Player) sender;
 
-        if (args.length != 1) {
-            player.sendMessage("Usage: /serverlink <overrideResource|resetResource|addServerLink|removeServerLink|resetServerLinks>");
+        if (args.length < 1) {
+            this.sendUsage(player);
             return true;
         }
 
@@ -80,12 +85,55 @@ public class ServerLinkCommand implements CommandExecutor {
                 break;
             }
 
+            case "legacyplacement": {
+                if (args.length != 2) {
+                    player.sendMessage("Usage: /serverlink legacyPlacement <" + String.join("|", LEGACY_PLACEMENTS) + ">");
+                    return true;
+                }
+
+                String placement = args[1].toUpperCase();
+
+                if (!LEGACY_PLACEMENTS.contains(placement)) {
+                    player.sendMessage("Invalid placement, must be one of: " + String.join("|", LEGACY_PLACEMENTS));
+                    return true;
+                }
+
+                serverLinkExample.setLegacyButtonPlacementExample(placement);
+                player.sendMessage("Legacy server link button placement has been set to " + placement);
+                break;
+            }
+
+            case "modernplacement": {
+                if (args.length != 2) {
+                    player.sendMessage("Usage: /serverlink modernPlacement <" + String.join("|", MODERN_PLACEMENTS) + ">");
+                    return true;
+                }
+
+                String placement = args[1].toUpperCase();
+
+                if (!MODERN_PLACEMENTS.contains(placement)) {
+                    player.sendMessage("Invalid placement, must be one of: " + String.join("|", MODERN_PLACEMENTS));
+                    return true;
+                }
+
+                serverLinkExample.setModernButtonPlacementExample(placement);
+                player.sendMessage("Modern server link button placement has been set to " + placement);
+                break;
+            }
+
             default: {
-                player.sendMessage("Usage: /serverlink <overrideResource|resetResource|addServerLink|removeServerLink|resetServerLinks>");
+                this.sendUsage(player);
                 break;
             }
         }
 
         return true;
+    }
+
+    private void sendUsage(Player player) {
+        player.sendMessage("Usage:");
+        player.sendMessage("/serverlink <overrideResource|resetResource|addServerLink|removeServerLink|resetServerLinks>");
+        player.sendMessage("/serverlink legacyPlacement <" + String.join("|", LEGACY_PLACEMENTS) + ">");
+        player.sendMessage("/serverlink modernPlacement <" + String.join("|", MODERN_PLACEMENTS) + ">");
     }
 }

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/module/ServerLinkJsonExample.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/module/ServerLinkJsonExample.java
@@ -30,6 +30,8 @@ import com.lunarclient.apollo.example.json.util.AdventureUtil;
 import com.lunarclient.apollo.example.json.util.JsonPacketUtil;
 import com.lunarclient.apollo.example.json.util.JsonUtil;
 import com.lunarclient.apollo.example.module.impl.ServerLinkExample;
+import java.util.HashMap;
+import java.util.Map;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -94,6 +96,24 @@ public class ServerLinkJsonExample extends ServerLinkExample {
         message.addProperty("@type", "type.googleapis.com/lunarclient.apollo.serverlink.v1.ResetServerLinksMessage");
 
         JsonPacketUtil.sendPacket(viewer, message);
+    }
+
+    @Override
+    public void setLegacyButtonPlacementExample(String placement) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("legacy-button-placement", placement);
+
+        JsonObject message = JsonUtil.createEnableModuleObjectWithType("server_link", properties);
+        JsonPacketUtil.broadcastPacket(message);
+    }
+
+    @Override
+    public void setModernButtonPlacementExample(String placement) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("modern-button-placement", placement);
+
+        JsonObject message = JsonUtil.createEnableModuleObjectWithType("server_link", properties);
+        JsonPacketUtil.broadcastPacket(message);
     }
 
 }

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
@@ -42,7 +42,7 @@ public final class JsonPacketUtil {
 
     private static final List<String> APOLLO_MODULES = Arrays.asList("auto_text_hotkey", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
         "cosmetic", "entity", "glint", "glow", "hologram", "inventory", "limb", "mod_setting", "nametag", "nick_hider", "notification", "pay_now", "packet_enrichment",
-        "rich_presence", "saturation", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
+        "rich_presence", "saturation", "server_link", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
     );
 
     // Module Id -> Option key -> Object
@@ -59,6 +59,8 @@ public final class JsonPacketUtil {
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item.send-packet", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item-bucket.send-packet", false);
+        CONFIG_MODULE_PROPERTIES.put("server_link", "legacy-button-placement", "NEW_ROW");
+        CONFIG_MODULE_PROPERTIES.put("server_link", "modern-button-placement", "REPLACE_REPORT_BUGS");
         CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-game", false);
         CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-commands", Arrays.asList("/server", "/servers", "/hub"));
         CONFIG_MODULE_PROPERTIES.put("server_rule", "disable-shaders", false);

--- a/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/module/ServerLinkProtoExample.java
+++ b/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/module/ServerLinkProtoExample.java
@@ -24,6 +24,8 @@
 package com.lunarclient.apollo.example.proto.module;
 
 import com.google.common.collect.Lists;
+import com.google.protobuf.Value;
+import com.lunarclient.apollo.configurable.v1.ConfigurableSettings;
 import com.lunarclient.apollo.example.module.impl.ServerLinkExample;
 import com.lunarclient.apollo.example.proto.util.AdventureUtil;
 import com.lunarclient.apollo.example.proto.util.ProtobufPacketUtil;
@@ -34,7 +36,9 @@ import com.lunarclient.apollo.serverlink.v1.RemoveServerLinkMessage;
 import com.lunarclient.apollo.serverlink.v1.ResetServerLinkResourceMessage;
 import com.lunarclient.apollo.serverlink.v1.ResetServerLinksMessage;
 import com.lunarclient.apollo.serverlink.v1.ServerLink;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -101,6 +105,24 @@ public class ServerLinkProtoExample extends ServerLinkExample {
     public void resetServerLinksExample(Player viewer) {
         ResetServerLinksMessage message = ResetServerLinksMessage.getDefaultInstance();
         ProtobufPacketUtil.sendPacket(viewer, message);
+    }
+
+    @Override
+    public void setLegacyButtonPlacementExample(String placement) {
+        Map<String, Value> properties = new HashMap<>();
+        properties.put("legacy-button-placement", Value.newBuilder().setStringValue(placement).build());
+
+        ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("server_link", properties);
+        ProtobufPacketUtil.broadcastPacket(settings);
+    }
+
+    @Override
+    public void setModernButtonPlacementExample(String placement) {
+        Map<String, Value> properties = new HashMap<>();
+        properties.put("modern-button-placement", Value.newBuilder().setStringValue(placement).build());
+
+        ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("server_link", properties);
+        ProtobufPacketUtil.broadcastPacket(settings);
     }
 
 }

--- a/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
+++ b/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
@@ -43,7 +43,7 @@ public final class ProtobufPacketUtil {
 
     private static final List<String> APOLLO_MODULES = Arrays.asList("auto_text_hotkey", "beam", "border", "chat", "colored_fire", "combat", "cooldown",
         "cosmetic", "entity", "glint", "glow", "hologram", "inventory", "limb", "mod_setting", "nametag", "nick_hider", "notification", "pay_now", "packet_enrichment",
-        "rich_presence", "saturation", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
+        "rich_presence", "saturation", "server_link", "server_rule", "staff_mod", "stopwatch", "team", "tebex", "title", "tnt_countdown", "transfer", "vignette", "waypoint"
     );
 
     // Module Id -> Option key -> Value
@@ -60,6 +60,8 @@ public final class ProtobufPacketUtil {
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-close.send-packet", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item.send-packet", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-use-item-bucket.send-packet", Value.newBuilder().setBoolValue(false).build());
+        CONFIG_MODULE_PROPERTIES.put("server_link", "legacy-button-placement", Value.newBuilder().setStringValue("NEW_ROW").build());
+        CONFIG_MODULE_PROPERTIES.put("server_link", "modern-button-placement", Value.newBuilder().setStringValue("REPLACE_REPORT_BUGS").build());
         CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-game", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("server_rule", "competitive-commands", Value.newBuilder().setListValue(
             ListValue.newBuilder().addAllValues(Arrays.asList(


### PR DESCRIPTION
## Overview

**Description:**
Adds options to the **ServerLink Module** that let servers choose where the Server Links button is placed in the pause menu.

**Changes:**
- New options:
  - `LEGACY_BUTTON_PLACEMENT`: (1.7–1.12). Default `NEW_ROW`.
  - `MODERN_BUTTON_PLACEMENT`: (1.16.1+). Default `REPLACE_REPORT_BUGS`. 
- New enums:
  - `LegacyServerLinkPlacement`: `NEW_ROW`, `REPLACE_ACHIEVEMENTS`, `REPLACE_STATISTICS`
  - `ModernServerLinkPlacement`: `REPLACE_REPORT_BUGS`, `REPLACE_ACHIEVEMENTS`, `REPLACE_STATISTICS`

**Code Example (If applicable):**
```java
public void setButtonPlacementExample() {
    // Legacy pause menu (1.7-1.12): NEW_ROW (default), REPLACE_ACHIEVEMENTS, or REPLACE_STATISTICS
    this.serverLinkModule.getOptions().set(
        ServerLinkModule.LEGACY_BUTTON_PLACEMENT, LegacyServerLinkPlacement.REPLACE_ACHIEVEMENTS);

    // Modern pause menu (1.16.1+): REPLACE_REPORT_BUGS (default), REPLACE_ACHIEVEMENTS, or REPLACE_STATISTICS
    this.serverLinkModule.getOptions().set(
        ServerLinkModule.MODERN_BUTTON_PLACEMENT, ModernServerLinkPlacement.REPLACE_STATISTICS);
}
```

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
