### PR TITLE
Optimizations

### DIFF
--- a/api/src/bukkit/java/com/lunarclient/apollo/BukkitApollo.java
+++ b/api/src/bukkit/java/com/lunarclient/apollo/BukkitApollo.java
@@ -30,12 +30,11 @@ import com.lunarclient.apollo.common.location.ApolloPlayerLocation;
 import com.lunarclient.apollo.player.ApolloPlayer;
 import com.lunarclient.apollo.player.ApolloPlayerManager;
 import com.lunarclient.apollo.recipients.Recipients;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -81,11 +80,12 @@ public final class BukkitApollo {
      */
     public static Recipients getRecipientsFrom(@NonNull Collection<Player> players) {
         ApolloPlayerManager playerManager = Apollo.getPlayerManager();
-        List<ApolloPlayer> apolloPlayers = players.stream()
-            .map(player -> playerManager.getPlayer(player.getUniqueId()))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
+        List<ApolloPlayer> apolloPlayers = new ArrayList<>(players.size());
+
+        for (Player player : players) {
+            playerManager.getPlayer(player.getUniqueId())
+                .ifPresent(apolloPlayers::add);
+        }
 
         return Recipients.of(apolloPlayers);
     }

--- a/api/src/bungee/java/com/lunarclient/apollo/BungeeApollo.java
+++ b/api/src/bungee/java/com/lunarclient/apollo/BungeeApollo.java
@@ -26,12 +26,11 @@ package com.lunarclient.apollo;
 import com.lunarclient.apollo.player.ApolloPlayer;
 import com.lunarclient.apollo.player.ApolloPlayerManager;
 import com.lunarclient.apollo.recipients.Recipients;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
@@ -74,11 +73,12 @@ public final class BungeeApollo {
      */
     public static Recipients getRecipientsFrom(@NonNull Collection<ProxiedPlayer> players) {
         ApolloPlayerManager playerManager = Apollo.getPlayerManager();
-        List<ApolloPlayer> apolloPlayers = players.stream()
-            .map(player -> playerManager.getPlayer(player.getUniqueId()))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
+        List<ApolloPlayer> apolloPlayers = new ArrayList<>(players.size());
+
+        for (ProxiedPlayer player : players) {
+            playerManager.getPlayer(player.getUniqueId())
+                .ifPresent(apolloPlayers::add);
+        }
 
         return Recipients.of(apolloPlayers);
     }

--- a/api/src/folia/java/com/lunarclient/apollo/FoliaApollo.java
+++ b/api/src/folia/java/com/lunarclient/apollo/FoliaApollo.java
@@ -30,12 +30,11 @@ import com.lunarclient.apollo.common.location.ApolloPlayerLocation;
 import com.lunarclient.apollo.player.ApolloPlayer;
 import com.lunarclient.apollo.player.ApolloPlayerManager;
 import com.lunarclient.apollo.recipients.Recipients;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -81,11 +80,12 @@ public final class FoliaApollo {
      */
     public static Recipients getRecipientsFrom(@NonNull Collection<Player> players) {
         ApolloPlayerManager playerManager = Apollo.getPlayerManager();
-        List<ApolloPlayer> apolloPlayers = players.stream()
-            .map(player -> playerManager.getPlayer(player.getUniqueId()))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
+        List<ApolloPlayer> apolloPlayers = new ArrayList<>(players.size());
+
+        for (Player player : players) {
+            playerManager.getPlayer(player.getUniqueId())
+                .ifPresent(apolloPlayers::add);
+        }
 
         return Recipients.of(apolloPlayers);
     }

--- a/api/src/main/java/com/lunarclient/apollo/event/EventBus.java
+++ b/api/src/main/java/com/lunarclient/apollo/event/EventBus.java
@@ -26,6 +26,7 @@ package com.lunarclient.apollo.event;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -96,7 +97,8 @@ public final class EventBus {
         for (Method method : this.getEventMethods(instance)) {
             List<Consumer<? extends Event>> listeners = this.events.get(method.getParameterTypes()[0]);
             if (listeners != null) {
-                listeners.removeIf(consumer -> consumer instanceof ReflectiveConsumer && ((ReflectiveConsumer<?>) consumer).getInstance() == instance);
+                listeners.removeIf(consumer -> consumer instanceof ReflectiveConsumer
+                    && ((ReflectiveConsumer<?>) consumer).getInstance() == instance);
             }
         }
     }
@@ -127,17 +129,24 @@ public final class EventBus {
     @SuppressWarnings("unchecked")
     public <T extends Event> EventResult<T> post(@NonNull T event) {
         CopyOnWriteArrayList<Consumer<? extends Event>> consumers = this.events.get(event.getClass());
-        List<Throwable> throwables = new ArrayList<>();
-        if (consumers != null) {
-            for (Consumer<? extends Event> consumer : consumers) {
-                try {
-                    ((Consumer<T>) consumer).accept(event);
-                } catch (Throwable throwable) {
-                    throwables.add(throwable);
+        if (consumers == null || consumers.isEmpty()) {
+            return new EventResult<>(event, Collections.emptyList());
+        }
+
+        List<Throwable> throwables = null;
+        for (Consumer<? extends Event> consumer : consumers) {
+            try {
+                ((Consumer<T>) consumer).accept(event);
+            } catch (Throwable throwable) {
+                if (throwables == null) {
+                    throwables = new ArrayList<>();
                 }
+
+                throwables.add(throwable);
             }
         }
-        return new EventResult<>(event, throwables);
+
+        return new EventResult<>(event, throwables == null ? Collections.emptyList() : throwables);
     }
 
     private List<Method> getEventMethods(Object instance) {

--- a/api/src/main/java/com/lunarclient/apollo/option/Option.java
+++ b/api/src/main/java/com/lunarclient/apollo/option/Option.java
@@ -130,6 +130,15 @@ public abstract class Option<V, M extends OptionBuilder<V, M, I>, I extends Opti
      */
     boolean notify;
 
+    /**
+     * Returns the option key.
+     *
+     * @return the key string
+     * @since 1.2.8
+     */
+    @EqualsAndHashCode.Exclude
+    String key;
+
     Option(M builder) {
         this.path = requireNonNull(builder.node, "node");
         this.typeToken = requireNonNull(builder.typeToken, "typeToken");
@@ -137,16 +146,8 @@ public abstract class Option<V, M extends OptionBuilder<V, M, I>, I extends Opti
         this.comment = builder.comment;
         this.defaultValue = builder.defaultValue;
         this.notify = builder.notify;
-    }
 
-    /**
-     * Returns the key as a joined {@link String}.
-     *
-     * @return the key string
-     * @since 1.0.0
-     */
-    public String getKey() {
-        return String.join(".", this.getPath());
+        this.key = String.join(".", this.path);
     }
 
     @Override

--- a/api/src/minestom/java/com/lunarclient/apollo/MinestomApollo.java
+++ b/api/src/minestom/java/com/lunarclient/apollo/MinestomApollo.java
@@ -27,12 +27,11 @@ import com.lunarclient.apollo.common.ApolloEntity;
 import com.lunarclient.apollo.player.ApolloPlayer;
 import com.lunarclient.apollo.player.ApolloPlayerManager;
 import com.lunarclient.apollo.recipients.Recipients;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
@@ -76,11 +75,12 @@ public final class MinestomApollo {
      */
     public static Recipients getRecipientsFrom(@NonNull Collection<Player> players) {
         ApolloPlayerManager playerManager = Apollo.getPlayerManager();
-        List<ApolloPlayer> apolloPlayers = players.stream()
-            .map(player -> playerManager.getPlayer(player.getUuid()))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
+        List<ApolloPlayer> apolloPlayers = new ArrayList<>(players.size());
+
+        for (Player player : players) {
+            playerManager.getPlayer(player.getUuid())
+                .ifPresent(apolloPlayers::add);
+        }
 
         return Recipients.of(apolloPlayers);
     }

--- a/api/src/velocity/java/com/lunarclient/apollo/VelocityApollo.java
+++ b/api/src/velocity/java/com/lunarclient/apollo/VelocityApollo.java
@@ -27,12 +27,11 @@ import com.lunarclient.apollo.player.ApolloPlayer;
 import com.lunarclient.apollo.player.ApolloPlayerManager;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.velocitypowered.api.proxy.Player;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 
 /**
@@ -75,11 +74,12 @@ public final class VelocityApollo {
      */
     public static Recipients getRecipientsFrom(@NonNull Collection<Player> players) {
         ApolloPlayerManager playerManager = Apollo.getPlayerManager();
-        List<ApolloPlayer> apolloPlayers = players.stream()
-            .map(player -> playerManager.getPlayer(player.getUniqueId()))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
+        List<ApolloPlayer> apolloPlayers = new ArrayList<>(players.size());
+
+        for (Player player : players) {
+            playerManager.getPlayer(player.getUniqueId())
+                .ifPresent(apolloPlayers::add);
+        }
 
         return Recipients.of(apolloPlayers);
     }

--- a/common/src/main/java/com/lunarclient/apollo/module/beam/BeamModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/beam/BeamModuleImpl.java
@@ -23,11 +23,11 @@
  */
 package com.lunarclient.apollo.module.beam;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.beam.v1.DisplayBeaconBeamMessage;
 import com.lunarclient.apollo.beam.v1.RemoveBeaconBeamMessage;
 import com.lunarclient.apollo.beam.v1.ResetBeaconBeamsMessage;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import lombok.NonNull;
 
@@ -46,7 +46,7 @@ public final class BeamModuleImpl extends BeamModule {
             .setColor(NetworkTypes.toProtobuf(beam.getColor()))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -55,7 +55,7 @@ public final class BeamModuleImpl extends BeamModule {
             .setId(beamId)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -66,7 +66,7 @@ public final class BeamModuleImpl extends BeamModule {
     @Override
     public void resetBeams(@NonNull Recipients recipients) {
         ResetBeaconBeamsMessage message = ResetBeaconBeamsMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/border/BorderModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/border/BorderModuleImpl.java
@@ -23,11 +23,11 @@
  */
 package com.lunarclient.apollo.module.border;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.border.v1.DisplayBorderMessage;
 import com.lunarclient.apollo.border.v1.RemoveBorderMessage;
 import com.lunarclient.apollo.border.v1.ResetBordersMessage;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import lombok.NonNull;
 
@@ -53,7 +53,7 @@ public final class BorderModuleImpl extends BorderModule {
             .setDurationTicks(checkPositive(border.getDurationTicks(), "Border#durationTicks"))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -62,7 +62,7 @@ public final class BorderModuleImpl extends BorderModule {
             .setId(borderId)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -73,7 +73,7 @@ public final class BorderModuleImpl extends BorderModule {
     @Override
     public void resetBorders(@NonNull Recipients recipients) {
         ResetBordersMessage message = ResetBordersMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/chat/ChatModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/chat/ChatModuleImpl.java
@@ -23,10 +23,10 @@
  */
 package com.lunarclient.apollo.module.chat;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.chat.v1.DisplayLiveChatMessageMessage;
 import com.lunarclient.apollo.chat.v1.RemoveLiveChatMessageMessage;
 import com.lunarclient.apollo.common.ApolloComponent;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import lombok.NonNull;
 import net.kyori.adventure.text.Component;
@@ -45,7 +45,7 @@ public final class ChatModuleImpl extends ChatModule {
             .setMessageId(messageId)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -54,7 +54,7 @@ public final class ChatModuleImpl extends ChatModule {
             .setMessageId(messageId)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/coloredfire/ColoredFireModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/coloredfire/ColoredFireModuleImpl.java
@@ -23,11 +23,11 @@
  */
 package com.lunarclient.apollo.module.coloredfire;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.coloredfire.v1.OverrideColoredFireMessage;
 import com.lunarclient.apollo.coloredfire.v1.ResetColoredFireMessage;
 import com.lunarclient.apollo.coloredfire.v1.ResetColoredFiresMessage;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import java.awt.Color;
 import java.util.UUID;
@@ -47,7 +47,7 @@ public final class ColoredFireModuleImpl extends ColoredFireModule {
             .setColor(NetworkTypes.toProtobuf(color))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -56,13 +56,13 @@ public final class ColoredFireModuleImpl extends ColoredFireModule {
             .setPlayerUuid(NetworkTypes.toProtobuf(burningPlayer))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetColoredFires(@NonNull Recipients recipients) {
         ResetColoredFiresMessage message = ResetColoredFiresMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/cooldown/CooldownModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/cooldown/CooldownModuleImpl.java
@@ -23,11 +23,11 @@
  */
 package com.lunarclient.apollo.module.cooldown;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.cooldown.v1.DisplayCooldownMessage;
 import com.lunarclient.apollo.cooldown.v1.RemoveCooldownMessage;
 import com.lunarclient.apollo.cooldown.v1.ResetCooldownsMessage;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import java.awt.Color;
 import lombok.NonNull;
@@ -52,7 +52,7 @@ public final class CooldownModuleImpl extends CooldownModule {
         }
 
         DisplayCooldownMessage message = builder.build();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -61,7 +61,7 @@ public final class CooldownModuleImpl extends CooldownModule {
             .setName(cooldownName)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -72,7 +72,7 @@ public final class CooldownModuleImpl extends CooldownModule {
     @Override
     public void resetCooldowns(@NonNull Recipients recipients) {
         ResetCooldownsMessage message = ResetCooldownsMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     private com.lunarclient.apollo.cooldown.v1.CooldownStyle toProtobuf(CooldownStyle style) {

--- a/common/src/main/java/com/lunarclient/apollo/module/cosmetic/CosmeticModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/cosmetic/CosmeticModuleImpl.java
@@ -23,6 +23,7 @@
  */
 package com.lunarclient.apollo.module.cosmetic;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.location.ApolloBlockLocation;
 import com.lunarclient.apollo.cosmetic.v1.DisplaySprayMessage;
 import com.lunarclient.apollo.cosmetic.v1.EquipNpcCosmeticsMessage;
@@ -39,7 +40,6 @@ import com.lunarclient.apollo.module.cosmetic.options.CosmeticOptions;
 import com.lunarclient.apollo.module.cosmetic.options.HatOptions;
 import com.lunarclient.apollo.module.cosmetic.options.PetOptions;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import java.util.List;
 import java.util.UUID;
@@ -73,7 +73,7 @@ public final class CosmeticModuleImpl extends CosmeticModule {
             .setCopyLocalCosmetics(copyLocalCosmetics)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -87,7 +87,7 @@ public final class CosmeticModuleImpl extends CosmeticModule {
             .addAllCosmeticIds(validatedIds)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -96,7 +96,7 @@ public final class CosmeticModuleImpl extends CosmeticModule {
             .setNpcUuid(NetworkTypes.toProtobuf(npcUuid))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -109,7 +109,7 @@ public final class CosmeticModuleImpl extends CosmeticModule {
                 .build())
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -118,13 +118,13 @@ public final class CosmeticModuleImpl extends CosmeticModule {
             .setNpcUuid(NetworkTypes.toProtobuf(npcUuid))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetNpcEmotes(@NonNull Recipients recipients) {
         ResetNpcEmotesMessage message = ResetNpcEmotesMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -137,7 +137,7 @@ public final class CosmeticModuleImpl extends CosmeticModule {
             .setDuration(NetworkTypes.toProtobuf(spray.getDuration()))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -146,7 +146,7 @@ public final class CosmeticModuleImpl extends CosmeticModule {
             .setSprayId(checkStrictlyPositive(sprayId, "Spray#sprayId"))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -159,13 +159,13 @@ public final class CosmeticModuleImpl extends CosmeticModule {
         }
 
         RemoveSprayMessage message = builder.build();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetSprays(@NonNull Recipients recipients) {
         ResetSpraysMessage message = ResetSpraysMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     private com.lunarclient.apollo.cosmetic.v1.Cosmetic toProtobuf(Cosmetic cosmetic) {

--- a/common/src/main/java/com/lunarclient/apollo/module/entity/EntityModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/entity/EntityModuleImpl.java
@@ -23,6 +23,7 @@
  */
 package com.lunarclient.apollo.module.entity;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.ApolloEntity;
 import com.lunarclient.apollo.common.v1.EntityId;
 import com.lunarclient.apollo.entity.v1.FlipEntityMessage;
@@ -30,7 +31,6 @@ import com.lunarclient.apollo.entity.v1.OverrideRainbowSheepMessage;
 import com.lunarclient.apollo.entity.v1.ResetFlipedEntityMessage;
 import com.lunarclient.apollo.entity.v1.ResetRainbowSheepMessage;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import java.util.List;
 import java.util.Set;
@@ -54,7 +54,7 @@ public final class EntityModuleImpl extends EntityModule {
             .addAllEntityIds(sheepUuidsProto)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -67,7 +67,7 @@ public final class EntityModuleImpl extends EntityModule {
             .addAllEntityIds(sheepUuidsProto)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -80,7 +80,7 @@ public final class EntityModuleImpl extends EntityModule {
             .addAllEntityIds(entityUuidsProto)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -93,7 +93,7 @@ public final class EntityModuleImpl extends EntityModule {
             .addAllEntityIds(entityUuidsProto)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/glow/GlowModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/glow/GlowModuleImpl.java
@@ -23,11 +23,11 @@
  */
 package com.lunarclient.apollo.module.glow;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.glow.v1.OverrideGlowEffectMessage;
 import com.lunarclient.apollo.glow.v1.ResetGlowEffectMessage;
 import com.lunarclient.apollo.glow.v1.ResetGlowEffectsMessage;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import java.awt.Color;
 import java.util.UUID;
@@ -56,7 +56,7 @@ public final class GlowModuleImpl extends GlowModule {
         }
 
         OverrideGlowEffectMessage message = builder.build();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -65,13 +65,13 @@ public final class GlowModuleImpl extends GlowModule {
             .setPlayerUuid(NetworkTypes.toProtobuf(glowingPlayer))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetGlow(@NonNull Recipients recipients) {
         ResetGlowEffectsMessage message = ResetGlowEffectsMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/hologram/HologramModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/hologram/HologramModuleImpl.java
@@ -23,12 +23,12 @@
  */
 package com.lunarclient.apollo.module.hologram;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.ApolloComponent;
 import com.lunarclient.apollo.hologram.v1.DisplayHologramMessage;
 import com.lunarclient.apollo.hologram.v1.RemoveHologramMessage;
 import com.lunarclient.apollo.hologram.v1.ResetHologramsMessage;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import java.util.stream.Collectors;
 import lombok.NonNull;
@@ -54,7 +54,7 @@ public final class HologramModuleImpl extends HologramModule {
             .setShowBackground(hologram.isShowBackground())
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -63,7 +63,7 @@ public final class HologramModuleImpl extends HologramModule {
             .setId(hologramId)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -74,7 +74,7 @@ public final class HologramModuleImpl extends HologramModule {
     @Override
     public void resetHolograms(@NonNull Recipients recipients) {
         ResetHologramsMessage message = ResetHologramsMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/limb/LimbModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/limb/LimbModuleImpl.java
@@ -23,12 +23,12 @@
  */
 package com.lunarclient.apollo.module.limb;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.limb.v1.HideArmorPiecesMessage;
 import com.lunarclient.apollo.limb.v1.HideBodyPartMessage;
 import com.lunarclient.apollo.limb.v1.ResetArmorPiecesMessage;
 import com.lunarclient.apollo.limb.v1.ResetBodyPartMessage;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import java.util.Collection;
 import java.util.Set;
@@ -54,7 +54,7 @@ public final class LimbModuleImpl extends LimbModule {
             .addAllArmorPieces(pieces)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -68,7 +68,7 @@ public final class LimbModuleImpl extends LimbModule {
             .addAllArmorPieces(pieces)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -82,7 +82,7 @@ public final class LimbModuleImpl extends LimbModule {
             .addAllBodyParts(parts)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -96,7 +96,7 @@ public final class LimbModuleImpl extends LimbModule {
             .addAllBodyParts(parts)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     private com.lunarclient.apollo.limb.v1.ArmorPiece toProtobuf(ArmorPiece armorPiece) {

--- a/common/src/main/java/com/lunarclient/apollo/module/nametag/NametagModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/nametag/NametagModuleImpl.java
@@ -30,10 +30,9 @@ import com.lunarclient.apollo.nametag.v1.ResetNametagMessage;
 import com.lunarclient.apollo.nametag.v1.ResetNametagsMessage;
 import com.lunarclient.apollo.network.NetworkTypes;
 import com.lunarclient.apollo.recipients.Recipients;
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.NonNull;
+import net.kyori.adventure.text.Component;
 
 /**
  * Provides the nametag module.
@@ -44,16 +43,14 @@ public final class NametagModuleImpl extends NametagModule {
 
     @Override
     public void overrideNametag(@NonNull Recipients recipients, @NonNull UUID playerUuid, @NonNull Nametag nametag) {
-        List<String> lines = nametag.getLines().stream()
-            .map(ApolloComponent::toJson)
-            .collect(Collectors.toList());
+        OverrideNametagMessage.Builder builder = OverrideNametagMessage.newBuilder()
+            .setPlayerUuid(NetworkTypes.toProtobuf(playerUuid));
 
-        OverrideNametagMessage message = OverrideNametagMessage.newBuilder()
-            .setPlayerUuid(NetworkTypes.toProtobuf(playerUuid))
-            .addAllAdventureJsonLines(lines)
-            .build();
+        for (Component line : nametag.getLines()) {
+            builder.addAdventureJsonLines(ApolloComponent.toJson(line));
+        }
 
-        ApolloManager.getNetworkManager().sendPacket(recipients, message);
+        ApolloManager.getNetworkManager().sendPacket(recipients, builder.build());
     }
 
     @Override

--- a/common/src/main/java/com/lunarclient/apollo/module/nametag/NametagModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/nametag/NametagModuleImpl.java
@@ -23,12 +23,12 @@
  */
 package com.lunarclient.apollo.module.nametag;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.ApolloComponent;
 import com.lunarclient.apollo.nametag.v1.OverrideNametagMessage;
 import com.lunarclient.apollo.nametag.v1.ResetNametagMessage;
 import com.lunarclient.apollo.nametag.v1.ResetNametagsMessage;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import java.util.List;
 import java.util.UUID;
@@ -53,7 +53,7 @@ public final class NametagModuleImpl extends NametagModule {
             .addAllAdventureJsonLines(lines)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -62,13 +62,13 @@ public final class NametagModuleImpl extends NametagModule {
             .setPlayerUuid(NetworkTypes.toProtobuf(playerUuid))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetNametags(@NonNull Recipients recipients) {
         ResetNametagsMessage message = ResetNametagsMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/nickhider/NickHiderModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/nickhider/NickHiderModuleImpl.java
@@ -23,9 +23,9 @@
  */
 package com.lunarclient.apollo.module.nickhider;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.nickhider.v1.OverrideNickHiderMessage;
 import com.lunarclient.apollo.nickhider.v1.ResetNickHiderMessage;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import lombok.NonNull;
 
@@ -42,13 +42,13 @@ public final class NickHiderModuleImpl extends NickHiderModule {
             .setNick(nick)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetNick(@NonNull Recipients recipients) {
         ResetNickHiderMessage message = ResetNickHiderMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/notification/NotificationModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/notification/NotificationModuleImpl.java
@@ -23,11 +23,11 @@
  */
 package com.lunarclient.apollo.module.notification;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.ApolloComponent;
 import com.lunarclient.apollo.network.NetworkTypes;
 import com.lunarclient.apollo.notification.v1.DisplayNotificationMessage;
 import com.lunarclient.apollo.notification.v1.ResetNotificationsMessage;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import lombok.NonNull;
 import net.kyori.adventure.text.Component;
@@ -70,13 +70,13 @@ public final class NotificationModuleImpl extends NotificationModule {
         }
 
         DisplayNotificationMessage message = builder.build();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetNotifications(@NonNull Recipients recipients) {
         ResetNotificationsMessage message = ResetNotificationsMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/paynow/PayNowModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/paynow/PayNowModuleImpl.java
@@ -23,8 +23,8 @@
  */
 package com.lunarclient.apollo.module.paynow;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.paynow.v1.OpenPayNowEmbeddedCheckoutMessage;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import lombok.NonNull;
 
@@ -41,7 +41,7 @@ public final class PayNowModuleImpl extends PayNowModule {
             .setCheckoutToken(checkoutToken)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/richpresence/RichPresenceModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/richpresence/RichPresenceModuleImpl.java
@@ -23,7 +23,7 @@
  */
 package com.lunarclient.apollo.module.richpresence;
 
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.richpresence.v1.OverrideServerRichPresenceMessage;
 import com.lunarclient.apollo.richpresence.v1.ResetServerRichPresenceMessage;
@@ -73,13 +73,13 @@ public final class RichPresenceModuleImpl extends RichPresenceModule {
         }
 
         OverrideServerRichPresenceMessage message = builder.build();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetServerRichPresence(@NonNull Recipients recipients) {
         ResetServerRichPresenceMessage message = ResetServerRichPresenceMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/serverlink/ServerLinkModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/serverlink/ServerLinkModuleImpl.java
@@ -23,10 +23,10 @@
  */
 package com.lunarclient.apollo.module.serverlink;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.ApolloComponent;
 import com.lunarclient.apollo.common.icon.ResourceLocationIcon;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.serverlink.v1.AddServerLinkMessage;
 import com.lunarclient.apollo.serverlink.v1.OverrideServerLinkResourceMessage;
@@ -51,13 +51,13 @@ public final class ServerLinkModuleImpl extends ServerLinkModule {
             .setIcon(NetworkTypes.toProtobuf(icon))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetServerLinkResource(@NonNull Recipients recipients) {
         ResetServerLinkResourceMessage message = ResetServerLinkResourceMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -75,7 +75,7 @@ public final class ServerLinkModuleImpl extends ServerLinkModule {
             .addAllServerLinks(serverLinksProto)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -94,13 +94,13 @@ public final class ServerLinkModuleImpl extends ServerLinkModule {
             .addAllServerLinkIds(serverLinkIds)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetServerLinks(@NonNull Recipients recipients) {
         ResetServerLinksMessage message = ResetServerLinksMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     private com.lunarclient.apollo.serverlink.v1.ServerLink toProtobuf(ServerLink serverLink) {

--- a/common/src/main/java/com/lunarclient/apollo/module/staffmod/StaffModModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/staffmod/StaffModModuleImpl.java
@@ -23,7 +23,7 @@
  */
 package com.lunarclient.apollo.module.staffmod;
 
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.staffmod.v1.DisableStaffModsMessage;
 import com.lunarclient.apollo.staffmod.v1.EnableStaffModsMessage;
@@ -62,7 +62,7 @@ public final class StaffModModuleImpl extends StaffModModule {
             .addAllStaffMods(staffModsProto)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -75,17 +75,17 @@ public final class StaffModModuleImpl extends StaffModModule {
             .addAllStaffMods(staffModsProto)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void enableAllStaffMods(@NonNull Recipients recipients) {
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(this.enableAllStaffModsMessage));
+        ApolloManager.getNetworkManager().sendPacket(recipients, this.enableAllStaffModsMessage);
     }
 
     @Override
     public void disableAllStaffMods(@NonNull Recipients recipients) {
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(this.disableAllStaffModsMessage));
+        ApolloManager.getNetworkManager().sendPacket(recipients, this.disableAllStaffModsMessage);
     }
 
     private com.lunarclient.apollo.staffmod.v1.StaffMod toProtobuf(StaffMod staffMod) {

--- a/common/src/main/java/com/lunarclient/apollo/module/stopwatch/StopwatchModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/stopwatch/StopwatchModuleImpl.java
@@ -23,10 +23,10 @@
  */
 package com.lunarclient.apollo.module.stopwatch;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.ApolloComponent;
 import com.lunarclient.apollo.common.location.HudPosition;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.stopwatch.v1.AddStopwatchMessage;
 import com.lunarclient.apollo.stopwatch.v1.AddTimerMessage;
@@ -54,19 +54,19 @@ public final class StopwatchModuleImpl extends StopwatchModule {
     @Override
     public void startStopwatch(@NonNull Recipients recipients) {
         StartStopwatchMessage message = StartStopwatchMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void stopStopwatch(@NonNull Recipients recipients) {
         StopStopwatchMessage message = StopStopwatchMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetStopwatch(@NonNull Recipients recipients) {
         ResetStopwatchMessage message = ResetStopwatchMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -94,7 +94,7 @@ public final class StopwatchModuleImpl extends StopwatchModule {
         }
 
         AddStopwatchMessage message = builder.build();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -103,7 +103,7 @@ public final class StopwatchModuleImpl extends StopwatchModule {
             .setId(id)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -112,7 +112,7 @@ public final class StopwatchModuleImpl extends StopwatchModule {
             .setId(id)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -121,7 +121,7 @@ public final class StopwatchModuleImpl extends StopwatchModule {
             .setId(id)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -130,13 +130,13 @@ public final class StopwatchModuleImpl extends StopwatchModule {
             .setId(id)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetStopwatches(@NonNull Recipients recipients) {
         ResetStopwatchesMessage message = ResetStopwatchesMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -171,7 +171,7 @@ public final class StopwatchModuleImpl extends StopwatchModule {
         }
 
         AddTimerMessage message = builder.build();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -180,7 +180,7 @@ public final class StopwatchModuleImpl extends StopwatchModule {
             .setId(id)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -189,7 +189,7 @@ public final class StopwatchModuleImpl extends StopwatchModule {
             .setId(id)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -198,7 +198,7 @@ public final class StopwatchModuleImpl extends StopwatchModule {
             .setId(id)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -207,13 +207,13 @@ public final class StopwatchModuleImpl extends StopwatchModule {
             .setId(id)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetTimers(@NonNull Recipients recipients) {
         ResetTimersMessage message = ResetTimersMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/team/TeamModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/team/TeamModuleImpl.java
@@ -32,7 +32,6 @@ import com.lunarclient.apollo.team.v1.ResetTeamMembersMessage;
 import com.lunarclient.apollo.team.v1.UpdateTeamMembersMessage;
 import java.awt.Color;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import net.kyori.adventure.text.Component;
 
@@ -45,15 +44,13 @@ public final class TeamModuleImpl extends TeamModule {
 
     @Override
     public void updateTeamMembers(@NonNull Recipients recipients, @NonNull List<TeamMember> teamMembers) {
-        List<com.lunarclient.apollo.team.v1.TeamMember> teamMembersProto = teamMembers.stream()
-            .map(this::toProtobuf)
-            .collect(Collectors.toList());
+        UpdateTeamMembersMessage.Builder builder = UpdateTeamMembersMessage.newBuilder();
 
-        UpdateTeamMembersMessage message = UpdateTeamMembersMessage.newBuilder()
-            .addAllMembers(teamMembersProto)
-            .build();
+        for (TeamMember teamMember : teamMembers) {
+            builder.addMembers(this.toProtobuf(teamMember));
+        }
 
-        ApolloManager.getNetworkManager().sendPacket(recipients, message);
+        ApolloManager.getNetworkManager().sendPacket(recipients, builder.build());
     }
 
     @Override

--- a/common/src/main/java/com/lunarclient/apollo/module/team/TeamModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/team/TeamModuleImpl.java
@@ -23,10 +23,10 @@
  */
 package com.lunarclient.apollo.module.team;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.ApolloComponent;
 import com.lunarclient.apollo.common.location.ApolloLocation;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.team.v1.ResetTeamMembersMessage;
 import com.lunarclient.apollo.team.v1.UpdateTeamMembersMessage;
@@ -53,13 +53,13 @@ public final class TeamModuleImpl extends TeamModule {
             .addAllMembers(teamMembersProto)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetTeamMembers(@NonNull Recipients recipients) {
         ResetTeamMembersMessage message = ResetTeamMembersMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     private com.lunarclient.apollo.team.v1.TeamMember toProtobuf(TeamMember member) {

--- a/common/src/main/java/com/lunarclient/apollo/module/tebex/TebexModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/tebex/TebexModuleImpl.java
@@ -23,7 +23,7 @@
  */
 package com.lunarclient.apollo.module.tebex;
 
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.tebex.v1.OpenTebexEmbeddedCheckoutMessage;
 import lombok.NonNull;
@@ -50,7 +50,7 @@ public final class TebexModuleImpl extends TebexModule {
         }
 
         OpenTebexEmbeddedCheckoutMessage message = builder.build();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/title/TitleModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/title/TitleModuleImpl.java
@@ -23,9 +23,9 @@
  */
 package com.lunarclient.apollo.module.title;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.ApolloComponent;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.title.v1.DisplayTitleMessage;
 import com.lunarclient.apollo.title.v1.ResetTitlesMessage;
@@ -54,13 +54,13 @@ public final class TitleModuleImpl extends TitleModule {
             .setInterpolationRate(checkPositive(title.getInterpolationRate(), "Title#interpolationRate"))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetTitles(@NonNull Recipients recipients) {
         ResetTitlesMessage message = ResetTitlesMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/tntcountdown/TntCountdownModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/tntcountdown/TntCountdownModuleImpl.java
@@ -23,9 +23,9 @@
  */
 package com.lunarclient.apollo.module.tntcountdown;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.ApolloEntity;
 import com.lunarclient.apollo.network.NetworkTypes;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.tntcountdown.v1.SetTntCountdownMessage;
 import lombok.NonNull;
@@ -51,7 +51,7 @@ public final class TntCountdownModuleImpl extends TntCountdownModule {
             .setDurationTicks(checkPositive(ticks, "TntCountdown#ticks"))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/vignette/VignetteModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/vignette/VignetteModuleImpl.java
@@ -23,7 +23,7 @@
  */
 package com.lunarclient.apollo.module.vignette;
 
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.vignette.v1.DisplayVignetteMessage;
 import com.lunarclient.apollo.vignette.v1.ResetVignetteMessage;
@@ -45,13 +45,13 @@ public final class VignetteModuleImpl extends VignetteModule {
             .setOpacity(checkRange(vignette.getOpacity(), 0, 1, "Vignette#opacity"))
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
     public void resetVignette(@NonNull Recipients recipients) {
         ResetVignetteMessage message = ResetVignetteMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
 }

--- a/common/src/main/java/com/lunarclient/apollo/module/waypoint/WaypointModuleImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/module/waypoint/WaypointModuleImpl.java
@@ -23,11 +23,11 @@
  */
 package com.lunarclient.apollo.module.waypoint;
 
+import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.common.location.ApolloBlockLocation;
 import com.lunarclient.apollo.event.player.ApolloRegisterPlayerEvent;
 import com.lunarclient.apollo.network.NetworkTypes;
 import com.lunarclient.apollo.option.config.Serializer;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.player.ApolloPlayer;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.waypoint.v1.DisplayWaypointMessage;
@@ -68,7 +68,7 @@ public final class WaypointModuleImpl extends WaypointModule implements Serializ
     @Override
     public void displayWaypoint(@NonNull Recipients recipients, @NonNull Waypoint waypoint) {
         DisplayWaypointMessage message = this.toProtobuf(waypoint);
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -77,7 +77,7 @@ public final class WaypointModuleImpl extends WaypointModule implements Serializ
             .setName(waypointName)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -88,7 +88,7 @@ public final class WaypointModuleImpl extends WaypointModule implements Serializ
     @Override
     public void resetWaypoints(@NonNull Recipients recipients) {
         ResetWaypointsMessage message = ResetWaypointsMessage.getDefaultInstance();
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -97,7 +97,7 @@ public final class WaypointModuleImpl extends WaypointModule implements Serializ
             .setName(waypointName)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     @Override
@@ -106,7 +106,7 @@ public final class WaypointModuleImpl extends WaypointModule implements Serializ
             .setName(waypointName)
             .build();
 
-        recipients.forEach(player -> ((AbstractApolloPlayer) player).sendPacket(message));
+        ApolloManager.getNetworkManager().sendPacket(recipients, message);
     }
 
     private void onPlayerRegister(ApolloRegisterPlayerEvent event) {
@@ -115,7 +115,7 @@ public final class WaypointModuleImpl extends WaypointModule implements Serializ
 
         if (waypoints != null) {
             for (Waypoint waypoint : waypoints) {
-                ((AbstractApolloPlayer) player).sendPacket(this.toProtobuf(waypoint));
+                ApolloManager.getNetworkManager().sendPacket(player, this.toProtobuf(waypoint));
             }
         }
     }

--- a/common/src/main/java/com/lunarclient/apollo/network/ApolloNetworkManager.java
+++ b/common/src/main/java/com/lunarclient/apollo/network/ApolloNetworkManager.java
@@ -24,6 +24,7 @@
 package com.lunarclient.apollo.network;
 
 import com.google.protobuf.Any;
+import com.google.protobuf.Message;
 import com.lunarclient.apollo.Apollo;
 import com.lunarclient.apollo.ApolloManager;
 import com.lunarclient.apollo.event.ApolloReceivePacketEvent;
@@ -31,6 +32,7 @@ import com.lunarclient.apollo.event.ApolloSendPacketEvent;
 import com.lunarclient.apollo.event.EventBus;
 import com.lunarclient.apollo.player.AbstractApolloPlayer;
 import com.lunarclient.apollo.player.ApolloPlayer;
+import com.lunarclient.apollo.recipients.Recipients;
 import java.util.UUID;
 import lombok.NoArgsConstructor;
 
@@ -60,6 +62,31 @@ public final class ApolloNetworkManager {
         for (Throwable throwable : result.getThrowing()) {
             throwable.printStackTrace();
         }
+    }
+
+    /**
+     * Sends the provided message packet to the provided {@link Recipients}.
+     *
+     * @param recipients the recipients to send the packet to
+     * @param message    the message to send
+     * @since 1.2.8
+     */
+    public void sendPacket(Recipients recipients, Message message) {
+        Any packet = Any.pack(message);
+        byte[] data = packet.toByteArray();
+
+        recipients.forEach(recipient -> {
+            EventBus.EventResult<ApolloSendPacketEvent> result = EventBus.getBus()
+                .post(new ApolloSendPacketEvent((ApolloPlayer) recipient, packet));
+
+            if (!result.getEvent().isCancelled()) {
+                ((AbstractApolloPlayer) recipient).sendPacket(data);
+            }
+
+            for (Throwable throwable : result.getThrowing()) {
+                throwable.printStackTrace();
+            }
+        });
     }
 
     /**

--- a/common/src/main/java/com/lunarclient/apollo/network/NetworkOptions.java
+++ b/common/src/main/java/com/lunarclient/apollo/network/NetworkOptions.java
@@ -32,8 +32,7 @@ import com.lunarclient.apollo.configurable.v1.OverrideConfigurableSettingsMessag
 import com.lunarclient.apollo.module.ApolloModule;
 import com.lunarclient.apollo.option.Option;
 import com.lunarclient.apollo.option.Options;
-import com.lunarclient.apollo.player.AbstractApolloPlayer;
-import com.lunarclient.apollo.player.ApolloPlayer;
+import com.lunarclient.apollo.recipients.Recipients;
 import io.leangen.geantyref.GenericTypeReflector;
 import java.awt.Color;
 import java.lang.reflect.AnnotatedParameterizedType;
@@ -52,18 +51,18 @@ import org.jetbrains.annotations.Nullable;
 public final class NetworkOptions {
 
     /**
-     * Send a single option to a single player.
+     * Send a single option to the provided {@link Recipients}.
      *
-     * @param module  the module the option belongs to
-     * @param key     the option key
-     * @param value   the option value
-     * @param players the players to send the option to
+     * @param module     the module the option belongs to
+     * @param key        the option key
+     * @param value      the option value
+     * @param recipients the recipients to send the option to
      * @since 1.0.0
      */
     public static void sendOption(@Nullable ApolloModule module,
                                   Option<?, ?, ?> key,
                                   Value value,
-                                  Iterable<ApolloPlayer> players) {
+                                  Recipients recipients) {
         if (!key.isNotify()) {
             return;
         }
@@ -73,35 +72,31 @@ public final class NetworkOptions {
         moduleBuilder.putProperties(key.getKey(), value);
         modulesBuilder.addConfigurableSettings(moduleBuilder.build());
 
-        for (ApolloPlayer player : players) {
-            ((AbstractApolloPlayer) player).sendPacket(modulesBuilder.build());
-        }
+        ApolloManager.getNetworkManager().sendPacket(recipients, modulesBuilder.build());
     }
 
     /**
      * Sends the provided {@link ApolloModule}s options to the provided
-     * {@link ApolloPlayer}s.
+     * {@link Recipients}.
      *
      * @param modules the modules to send the options of
      * @param onlyPresent send only the options that have a present value
-     * @param players the players to send the module options to
+     * @param recipients the recipients to send the module options to
      * @since 1.0.0
      */
     public static void sendOptions(Iterable<ApolloModule> modules,
                                    boolean onlyPresent,
-                                   ApolloPlayer... players) {
-        for (ApolloPlayer player : players) {
-            OverrideConfigurableSettingsMessage.Builder modulesBuilder = OverrideConfigurableSettingsMessage.newBuilder();
+                                   Recipients recipients) {
+        OverrideConfigurableSettingsMessage.Builder modulesBuilder = OverrideConfigurableSettingsMessage.newBuilder();
 
-            for (ApolloModule module : modules) {
-                modulesBuilder.addConfigurableSettings(NetworkOptions.moduleWithOptions(
-                    module,
-                    onlyPresent
-                ).build());
-            }
-
-            ((AbstractApolloPlayer) player).sendPacket(modulesBuilder.build());
+        for (ApolloModule module : modules) {
+            modulesBuilder.addConfigurableSettings(NetworkOptions.moduleWithOptions(
+                module,
+                onlyPresent
+            ).build());
         }
+
+        ApolloManager.getNetworkManager().sendPacket(recipients, modulesBuilder.build());
     }
 
     /**

--- a/common/src/main/java/com/lunarclient/apollo/option/OptionsImpl.java
+++ b/common/src/main/java/com/lunarclient/apollo/option/OptionsImpl.java
@@ -24,12 +24,12 @@
 package com.lunarclient.apollo.option;
 
 import com.google.protobuf.Value;
-import com.lunarclient.apollo.Apollo;
 import com.lunarclient.apollo.event.EventBus;
 import com.lunarclient.apollo.event.option.ApolloUpdateOptionEvent;
 import com.lunarclient.apollo.module.ApolloModule;
 import com.lunarclient.apollo.network.NetworkOptions;
 import com.lunarclient.apollo.player.ApolloPlayer;
+import com.lunarclient.apollo.recipients.Recipients;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -274,11 +274,9 @@ public class OptionsImpl implements Options {
             return;
         }
 
-        Collection<ApolloPlayer> players = player == null ? Apollo.getPlayerManager()
-            .getPlayers() : Collections.singleton(player);
-
+        Recipients recipients = player == null ? Recipients.ofEveryone() : player;
         Value valueWrapper = NetworkOptions.wrapValue(Value.newBuilder(), option.getTypeToken().getType(), value);
-        NetworkOptions.sendOption(this.module, option, valueWrapper, players);
+        NetworkOptions.sendOption(this.module, option, valueWrapper, recipients);
     }
 
 }

--- a/platform/bukkit/src/main/java/com/lunarclient/apollo/wrapper/BukkitApolloWorld.java
+++ b/platform/bukkit/src/main/java/com/lunarclient/apollo/wrapper/BukkitApolloWorld.java
@@ -25,14 +25,16 @@ package com.lunarclient.apollo.wrapper;
 
 import com.lunarclient.apollo.Apollo;
 import com.lunarclient.apollo.player.ApolloPlayer;
+import com.lunarclient.apollo.player.ApolloPlayerManager;
 import com.lunarclient.apollo.recipients.ForwardingRecipients;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.world.ApolloWorld;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 
 /**
  * The Bukkit implementation of {@link ApolloWorld}.
@@ -51,11 +53,16 @@ public final class BukkitApolloWorld implements ApolloWorld, ForwardingRecipient
 
     @Override
     public Collection<ApolloPlayer> getPlayers() {
-        return this.world.getPlayers().stream()
-            .map(player -> Apollo.getPlayerManager().getPlayer(player.getUniqueId()))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
+        ApolloPlayerManager playerManager = Apollo.getPlayerManager();
+        List<Player> players = this.world.getPlayers();
+        List<ApolloPlayer> apolloPlayers = new ArrayList<>(players.size());
+
+        for (Player player : players) {
+            playerManager.getPlayer(player.getUniqueId())
+                .ifPresent(apolloPlayers::add);
+        }
+
+        return apolloPlayers;
     }
 
     @Override

--- a/platform/folia/src/main/java/com/lunarclient/apollo/wrapper/FoliaApolloWorld.java
+++ b/platform/folia/src/main/java/com/lunarclient/apollo/wrapper/FoliaApolloWorld.java
@@ -25,14 +25,16 @@ package com.lunarclient.apollo.wrapper;
 
 import com.lunarclient.apollo.Apollo;
 import com.lunarclient.apollo.player.ApolloPlayer;
+import com.lunarclient.apollo.player.ApolloPlayerManager;
 import com.lunarclient.apollo.recipients.ForwardingRecipients;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.world.ApolloWorld;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.bukkit.World;
+import org.bukkit.entity.Player;
 
 /**
  * The Folia implementation of {@link ApolloWorld}.
@@ -51,11 +53,16 @@ public final class FoliaApolloWorld implements ApolloWorld, ForwardingRecipients
 
     @Override
     public Collection<ApolloPlayer> getPlayers() {
-        return this.world.getPlayers().stream()
-            .map(player -> Apollo.getPlayerManager().getPlayer(player.getUniqueId()))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
+        ApolloPlayerManager playerManager = Apollo.getPlayerManager();
+        List<Player> players = this.world.getPlayers();
+        List<ApolloPlayer> apolloPlayers = new ArrayList<>(players.size());
+
+        for (Player player : players) {
+            playerManager.getPlayer(player.getUniqueId())
+                .ifPresent(apolloPlayers::add);
+        }
+
+        return apolloPlayers;
     }
 
     @Override

--- a/platform/minestom/src/main/java/com/lunarclient/apollo/wrapper/MinestomApolloWorld.java
+++ b/platform/minestom/src/main/java/com/lunarclient/apollo/wrapper/MinestomApolloWorld.java
@@ -25,13 +25,16 @@ package com.lunarclient.apollo.wrapper;
 
 import com.lunarclient.apollo.Apollo;
 import com.lunarclient.apollo.player.ApolloPlayer;
+import com.lunarclient.apollo.player.ApolloPlayerManager;
 import com.lunarclient.apollo.recipients.ForwardingRecipients;
 import com.lunarclient.apollo.recipients.Recipients;
 import com.lunarclient.apollo.world.ApolloWorld;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
+import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 
 /**
@@ -51,11 +54,16 @@ public final class MinestomApolloWorld implements ApolloWorld, ForwardingRecipie
 
     @Override
     public Collection<ApolloPlayer> getPlayers() {
-        return this.instance.getPlayers().stream()
-            .map(player -> Apollo.getPlayerManager().getPlayer(player.getUuid()))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
+        ApolloPlayerManager playerManager = Apollo.getPlayerManager();
+        Set<Player> players = this.instance.getPlayers();
+        List<ApolloPlayer> apolloPlayers = new ArrayList<>(players.size());
+
+        for (Player player : players) {
+            playerManager.getPlayer(player.getUuid())
+                .ifPresent(apolloPlayers::add);
+        }
+
+        return apolloPlayers;
     }
 
     @Override

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,14 +1,6 @@
 pluginManagement {
     includeBuild("build-logic")
     repositories {
-        maven(url = "https://repo.stellardrift.ca/repository/internal/") {
-            name = "stellardriftReleases"
-            mavenContent { releasesOnly() }
-        }
-        maven(url = "https://repo.stellardrift.ca/repository/snapshots/") {
-            name = "stellardriftSnapshots"
-            mavenContent { snapshotsOnly() }
-        }
         gradlePluginPortal()
         maven("https://repo.jpenilla.xyz/snapshots")
     }


### PR DESCRIPTION
## Overview

**Description:**
Reduces overhead in frequently called code by avoiding redundant allocations and computation. No behavioral changes.

**Changes:**
- `EventBus#post`: lazily allocate the throwables list.
-  Packet broadcasting: pack/serialize each message once per broadcast instead of once per recipient.
- `Option#getKey`: cache the joined key instead of recomputing it per call.
- `ApolloWorld#getPlayers`, `Apollo#getRecipientsFrom`, `TeamModuleImpl`, `NametagModuleImpl`: streams -> loops.
- `NetworkOptions#sendOption(s)`: build the message once per broadcast.


---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
