### PR TITLE
Add `DISABLE_BLOCK_MISS_PENALTY` to Combat Module

### DIFF
--- a/api/src/main/java/com/lunarclient/apollo/module/combat/CombatModule.java
+++ b/api/src/main/java/com/lunarclient/apollo/module/combat/CombatModule.java
@@ -53,6 +53,22 @@ public final class CombatModule extends ApolloModule {
         .defaultValue(false).notifyClient().build();
 
     /**
+     * Whether the player gets a hit delay for a missed hit while
+     * targeting a block. Applies to all versions 1.8 and above.
+     *
+     * <p>Enabling this option may cause compatibility issues with anti-cheats.</p>
+     *
+     * @since 1.2.8
+     */
+    public static final SimpleOption<Boolean> DISABLE_BLOCK_MISS_PENALTY = Option.<Boolean>builder()
+        .comment(
+            "Set to 'true' to remove the miss penalty when targeting a block on all versions 1.8 and above, otherwise 'false'.",
+            "Enabling this option may cause compatibility issues with anti-cheats."
+        )
+        .node("disable-block-miss-penalty").type(TypeToken.get(Boolean.class))
+        .defaultValue(false).notifyClient().build();
+
+    /**
      * Whether the player can dig and use an item at the same time,
      * like in 1.7. Applies to all versions 1.8 and above.
      *
@@ -71,6 +87,7 @@ public final class CombatModule extends ApolloModule {
     CombatModule() {
         this.registerOptions(
             CombatModule.DISABLE_MISS_PENALTY,
+            CombatModule.DISABLE_BLOCK_MISS_PENALTY,
             CombatModule.ALLOW_DIG_AND_USE
         );
     }

--- a/docs/developers/lightweight/json/packet-util.mdx
+++ b/docs/developers/lightweight/json/packet-util.mdx
@@ -35,6 +35,7 @@ static {
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
     CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", false);
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
+    CONFIG_MODULE_PROPERTIES.put("combat", "disable-block-miss-penalty", false);
     CONFIG_MODULE_PROPERTIES.put("combat", "allow-dig-and-use", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", false);

--- a/docs/developers/lightweight/protobuf/packet-util.mdx
+++ b/docs/developers/lightweight/protobuf/packet-util.mdx
@@ -35,6 +35,7 @@ static {
     // While using the Apollo plugin this would be equivalent to modifying the config.yml
     CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
+    CONFIG_MODULE_PROPERTIES.put("combat", "disable-block-miss-penalty", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("combat", "allow-dig-and-use", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());
     CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", Value.newBuilder().setBoolValue(false).build());

--- a/docs/developers/modules/combat.mdx
+++ b/docs/developers/modules/combat.mdx
@@ -7,6 +7,7 @@ import { Callout, Tab, Tabs } from 'nextra-theme-docs'
 The combat module allows you to modify certain aspects of combat that are usually handled client-sided.
 
 - Adds the ability to disable the miss penalty, on all versions 1.8 and above.
+- Adds the ability to disable the miss penalty when targeting a block, on all versions 1.8 and above.
 - Adds the ability to dig and use an item at the same time, like in 1.7, on all versions 1.8 and above.
 
 ### Sample Code
@@ -25,6 +26,14 @@ Explore each integration by cycling through each tab, to find the best fit for y
 ```java
 public void setDisableMissPenalty(boolean value) {
     this.combatModule.getOptions().set(CombatModule.DISABLE_MISS_PENALTY, value);
+}
+```
+
+### Toggle Block Miss Penalty
+
+```java
+public void setDisableBlockMissPenalty(boolean value) {
+    this.combatModule.getOptions().set(CombatModule.DISABLE_BLOCK_MISS_PENALTY, value);
 }
 ```
 
@@ -50,6 +59,18 @@ public void setAllowDigAndUse(boolean value) {
 public void setDisableMissPenalty(boolean value) {
     Map<String, Value> properties = new HashMap<>();
     properties.put("disable-miss-penalty", Value.newBuilder().setBoolValue(value).build());
+
+    ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("combat", properties);
+    ProtobufPacketUtil.broadcastPacket(settings);
+}
+```
+
+**Toggle Block Miss Penalty**
+
+```java
+public void setDisableBlockMissPenalty(boolean value) {
+    Map<String, Value> properties = new HashMap<>();
+    properties.put("disable-block-miss-penalty", Value.newBuilder().setBoolValue(value).build());
 
     ConfigurableSettings settings = ProtobufPacketUtil.createModuleMessage("combat", properties);
     ProtobufPacketUtil.broadcastPacket(settings);
@@ -88,6 +109,18 @@ public void setDisableMissPenalty(boolean value) {
 }
 ```
 
+**Toggle Block Miss Penalty**
+
+```java
+public void setDisableBlockMissPenalty(boolean value) {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("disable-block-miss-penalty", value);
+
+    JsonObject message = JsonUtil.createEnableModuleObjectWithType("combat", properties);
+    JsonPacketUtil.broadcastPacket(message);
+}
+```
+
 **Toggle Dig and Use**
 
 ```java
@@ -108,6 +141,11 @@ public void setAllowDigAndUse(boolean value) {
 
 - __`DISABLE_MISS_PENALTY`__
     - Whether the player gets a hit delay for a missed hit. Enabling this option may cause compatibility issues with anti-cheats.
+    - Values
+        - Type: `Boolean`
+        - Default: `false`
+- __`DISABLE_BLOCK_MISS_PENALTY`__
+    - Whether the player gets a hit delay for a missed hit while targeting a block. Applies to all versions 1.8 and above. Enabling this option may cause compatibility issues with anti-cheats.
     - Values
         - Type: `Boolean`
         - Default: `false`

--- a/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
+++ b/example/bukkit/json/src/main/java/com/lunarclient/apollo/example/json/util/JsonPacketUtil.java
@@ -53,6 +53,7 @@ public final class JsonPacketUtil {
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
         CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", false);
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", false);
+        CONFIG_MODULE_PROPERTIES.put("combat", "disable-block-miss-penalty", false);
         CONFIG_MODULE_PROPERTIES.put("combat", "allow-dig-and-use", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", false);
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", false);

--- a/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
+++ b/example/bukkit/proto/src/main/java/com/lunarclient/apollo/example/proto/util/ProtobufPacketUtil.java
@@ -54,6 +54,7 @@ public final class ProtobufPacketUtil {
         // While using the Apollo plugin this would be equivalent to modifying the config.yml
         CONFIG_MODULE_PROPERTIES.put("colored_fire", "persist-colors-on-unload", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("combat", "disable-miss-penalty", Value.newBuilder().setBoolValue(false).build());
+        CONFIG_MODULE_PROPERTIES.put("combat", "disable-block-miss-penalty", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("combat", "allow-dig-and-use", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-attack.send-packet", Value.newBuilder().setBoolValue(false).build());
         CONFIG_MODULE_PROPERTIES.put("packet_enrichment", "player-chat-open.send-packet", Value.newBuilder().setBoolValue(false).build());


### PR DESCRIPTION
## Overview

**Description:**
Add `DISABLE_BLOCK_MISS_PENALTY` option to the CombatModule to remove the miss penalty when a player is targeting a block, on all versions 1.8 and above.

**Code Example (If applicable):**
```java
public void setDisableBlockMissPenalty(boolean value) {
    this.combatModule.getOptions().set(CombatModule.DISABLE_BLOCK_MISS_PENALTY, value);
}
```

---

## Review Request Checklist

- [x] Your code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have tested this change myself. (If applicable)
- [x] I have made corresponding changes to the documentation. (If applicable)
- [x] The branch name follows the projects naming conventions. (e.g. `feature/add-module` & `bugfix/fix-issue`)


---
